### PR TITLE
Add staticAttributions linking to the copyright information

### DIFF
--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -74,6 +74,10 @@ const commonLayers: LayerConfiguration[] = [
   },
 ]
 
+// TODO: Update link with reference to sbom
+const sbomAttributionAnchor =
+  '<a href="https://github.com/Dataport/polar/network/dependencies" target="_blank">Software Bill of Materials</a>'
+
 const commonAttributions: Partial<AttributionsConfiguration> = {
   initiallyOpen: false,
   layerAttributions: [
@@ -152,6 +156,16 @@ const mapConfigurations = {
             title: 'meldemichel.attributions.reports',
           },
         ],
+        staticAttributions: [
+          `<ul style="display: flex; column-gap: 8px; list-style-type: none; padding: 0">
+            <li>
+              <a href="https://www.hamburg.de/impressum/" target="_blank">Impressum</a>
+            </li>
+            <li>
+              ${sbomAttributionAnchor}
+            </li>
+          </ul>`,
+        ],
       },
       geoLocation,
       gfi: {
@@ -176,7 +190,10 @@ const mapConfigurations = {
     ...commonMapConfiguration,
     addressSearch,
     layers: commonLayers,
-    attributions: commonAttributions,
+    attributions: {
+      ...commonAttributions,
+      staticAttributions: [sbomAttributionAnchor],
+    },
     geoLocation,
     pins: commonPins,
     reverseGeocoder,
@@ -184,7 +201,10 @@ const mapConfigurations = {
   [MODE.SINGLE]: () => ({
     ...commonMapConfiguration,
     layers: commonLayers,
-    attributions: commonAttributions,
+    attributions: {
+      ...commonAttributions,
+      staticAttributions: [sbomAttributionAnchor],
+    },
     pins: commonPins,
   }),
 }

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -74,10 +74,6 @@ const commonLayers: LayerConfiguration[] = [
   },
 ]
 
-// TODO: Update link with reference to sbom
-const sbomAttributionAnchor =
-  '<a href="https://github.com/Dataport/polar/network/dependencies" target="_blank">Software Bill of Materials</a>'
-
 const commonAttributions: Partial<AttributionsConfiguration> = {
   initiallyOpen: false,
   layerAttributions: [
@@ -157,14 +153,7 @@ const mapConfigurations = {
           },
         ],
         staticAttributions: [
-          `<ul style="display: flex; column-gap: 8px; list-style-type: none; padding: 0">
-            <li>
-              <a href="https://www.hamburg.de/impressum/" target="_blank">Impressum</a>
-            </li>
-            <li>
-              ${sbomAttributionAnchor}
-            </li>
-          </ul>`,
+          '<a href="https://www.hamburg.de/impressum/" target="_blank">Impressum</a>',
         ],
       },
       geoLocation,
@@ -192,7 +181,6 @@ const mapConfigurations = {
     layers: commonLayers,
     attributions: {
       ...commonAttributions,
-      staticAttributions: [sbomAttributionAnchor],
     },
     geoLocation,
     pins: commonPins,
@@ -203,7 +191,6 @@ const mapConfigurations = {
     layers: commonLayers,
     attributions: {
       ...commonAttributions,
-      staticAttributions: [sbomAttributionAnchor],
     },
     pins: commonPins,
   }),


### PR DESCRIPTION
## Summary

Add staticAttributions linking to the copyright information and sbom.

## Instructions for local reproduction and review

- `npm run meldemichel:dev` and `npm run meldemichel:build && npm run meldemichel:build:example`
  - [x] Complete: Layer Attributions and Copyright Information of Hamburg City are shown
  - [x] Report and Single: Only Layer Attributions are shown

## Relevant tickets, issues, et cetera

#6
