### PR TITLE
fix icon menu content placement

### DIFF
--- a/packages/plugins/IconMenu/CHANGELOG.md
+++ b/packages/plugins/IconMenu/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unpublished
 
-- Fix: Attribution contents were rendered above map in certain circumstances. This has been resolved.
+- Fix: Plugin contents were rendered above map in certain circumstances. This has been resolved.
 
 ## 1.0.0
 

--- a/packages/plugins/IconMenu/CHANGELOG.md
+++ b/packages/plugins/IconMenu/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Attribution contents were rendered above map in certain circumstances. This has been resolved.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/plugins/IconMenu/src/components/IconMenu.vue
+++ b/packages/plugins/IconMenu/src/components/IconMenu.vue
@@ -45,7 +45,7 @@
               : 'icon-menu-list-item-content',
             'icon-menu-list-item-content-scrollable-y',
           ]"
-          :style="getContentStyle(Number(index))"
+          :style="`max-height: ${maxHeight};`"
         />
       </template>
     </component>
@@ -84,20 +84,6 @@ export default Vue.extend({
   },
   methods: {
     ...mapMutations('plugin/iconMenu', ['setOpen']),
-    getContentStyle(index: number) {
-      // HACK: Zoom is currently the only plugin that adds two buttons instead of one.
-      const zoomIndex = this.menus.findIndex(({ id }) => id === 'zoom')
-      const isAfterZoom = zoomIndex < index
-      return `max-height: ${this.maxHeight}; ${
-        this.isHorizontal
-          ? `right: calc(${
-              this.menus.length - (isAfterZoom ? index + 1 : index + 2)
-            } * (-100% - 0.5rem));`
-          : `top: calc(${
-              isAfterZoom && zoomIndex !== -1 ? index + 1 : index
-            } * (-100% - 0.5rem));`
-      }`
-    },
     toggle(index) {
       const { open } = this
       if (open === index) {
@@ -112,17 +98,17 @@ export default Vue.extend({
 
 <style lang="scss" scoped>
 .icon-menu-list {
+  position: relative;
   list-style: none;
+  padding: 0;
 }
 
 .icon-menu-list-item-horizontal {
-  position: relative;
   float: left;
   margin-left: 0.5rem;
 }
 
 .icon-menu-list-item {
-  position: relative;
   margin-bottom: 0.5rem;
   z-index: 1;
 }
@@ -130,13 +116,15 @@ export default Vue.extend({
 .icon-menu-list-item-content {
   position: absolute;
   white-space: nowrap;
-  right: calc(100% + 0.5rem);
+  top: 0;
+  right: calc(100% + 0.5em);
 }
 
 .icon-menu-list-item-content-horizontal {
   position: absolute;
   white-space: nowrap;
-  top: 3em;
+  top: calc(100% + 0.5em);
+  right: -0.5em;
 }
 
 .icon-menu-list-item-content-scrollable-y {


### PR DESCRIPTION
## Summary

- Replaced hack with absolute positioning.
- Fixed bug that appeared when Zoom was sorted prior to Attributions, but decided to not render itself due to tiny client window.
- Remove spacing on IconMenu's ul that seems to have leaked in unnoticed.

## Instructions for local reproduction and review

Run arbitrary clients in arbitrary environments to check if something is broken. Most notable change should occur in Meldemichel example clients for `'SINGLE'` mode, where the attributions were previously displayed above the map.
