### PR TITLE
deduplicate bound layer types

### DIFF
--- a/packages/lib/passesBoundaryCheck/index.ts
+++ b/packages/lib/passesBoundaryCheck/index.ts
@@ -2,6 +2,7 @@ import { Map } from 'ol'
 import { Coordinate } from 'ol/coordinate'
 import VectorLayer from 'ol/layer/Vector'
 import VectorSource from 'ol/source/Vector'
+import { LayerBoundPluginOptions } from '@polar/lib-custom-types'
 
 // arbitrarily give up after 10s of stalling
 let readinessChecks = 0
@@ -33,7 +34,7 @@ const isReady = async (source: VectorSource): Promise<boolean> => {
  */
 export const passesBoundaryCheck = async (
   map: Map,
-  boundaryLayerId: string | undefined,
+  boundaryLayerId: LayerBoundPluginOptions['boundaryLayerId'],
   coordinate: Coordinate
 ): Promise<boolean> => {
   if (typeof boundaryLayerId === 'undefined') {

--- a/packages/lib/passesBoundaryCheck/package.json
+++ b/packages/lib/passesBoundaryCheck/package.json
@@ -3,5 +3,8 @@
   "version": "1.0.0",
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataport-polar-support@dataport.de>",
-  "main": "index.ts"
+  "main": "index.ts",
+  "devDependencies": {
+    "@polar/lib-custom-types": "^1.0.0"
+  }
 }

--- a/packages/types/custom/CHANGELOG.md
+++ b/packages/types/custom/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Remodel type structure to deduplicate fields now modeled in `LayerBoundPluginOptions`.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/types/custom/core.ts
+++ b/packages/types/custom/core.ts
@@ -228,7 +228,21 @@ export interface GfiLayerConfiguration {
   format?: string
 }
 
-export interface GeoLocationConfiguration extends PluginOptions {
+export interface LayerBoundPluginOptions extends PluginOptions {
+  /**
+   * If set, feature will only be applicable within the layer's features.
+   * The layer must contain vectors. This is useful for restricted maps to avoid
+   * selecting unfit coordinates.
+   */
+  boundaryLayerId?: string
+  /**
+   * Used if boundaryLayer does not contain the plugin information to inform
+   * the user that something could not be set/updated.
+   */
+  toastAction?: string
+}
+
+export interface GeoLocationConfiguration extends LayerBoundPluginOptions {
   /**
    * Source paths through store to listen to for changes; it is assumed values
    * listened to are coordinates that can be used to request information from
@@ -243,17 +257,6 @@ export interface GeoLocationConfiguration extends PluginOptions {
    * limit an endless stream of returns to maybe 10 or so. Infinite by default.
    */
   zoomLevel: number
-  /**
-   * If set, geolocation will only occur within the layer's features.
-   * The layer must contain vectors. This is useful for restricted maps to avoid
-   * zooming to unreachable or tileless coordinates.
-   */
-  boundaryLayerId?: string
-  /**
-   * Used if boundaryLayer does not contain the user's geolocation to inform
-   * the user that geolocation ended up outside the map.
-   */
-  toastAction?: string
 }
 
 /** Object containing information for highlighting a gfi result */
@@ -330,23 +333,12 @@ interface PinStyle {
   stroke?: string
 }
 
-export interface PinsConfiguration extends PluginOptions {
+export interface PinsConfiguration extends LayerBoundPluginOptions {
   appearOnClick: AppearOnClick
   /** Path in store from where coordinates can be retrieved from. */
   coordinateSource: string
   /** The zoom level to zoom to when a pin is added to the map. */
   toZoomLevel: number
-  /**
-   * If set, Pins will only be set within the layer's features.
-   * The layer must contain vectors. This is useful for restricted maps to avoid
-   * selecting unfit coordinates.
-   */
-  boundaryLayerId?: string
-  /**
-   * Used if boundaryLayer does not contain the user's pin to inform
-   * the user that the pin could not be set/updated.
-   */
-  toastAction?: string
   /** If the pin should be movable; defaults to false. */
   movable?: boolean
   /** Pin styling */


### PR DESCRIPTION
## Summary

A common type for plugins bound by layer boundaries has been introduced.

## Instructions for local reproduction and review

Running pipeline is sufficient, no direct effects on code.
