### PR TITLE
Fix: Type access to core configuration

### DIFF
--- a/packages/plugins/AddressSearch/src/store/getters.ts
+++ b/packages/plugins/AddressSearch/src/store/getters.ts
@@ -58,7 +58,7 @@ const getters: PolarGetterTree<AddressSearchState, AddressSearchGetters> = {
   addressSearchConfiguration(_, __, ___, rootGetters) {
     return {
       ...defaultConfiguration,
-      ...(rootGetters?.configuration?.addressSearch || {}),
+      ...(rootGetters.configuration?.addressSearch || {}),
     }
   },
   minLength(_, { addressSearchConfiguration }) {

--- a/packages/plugins/Attributions/src/store/index.ts
+++ b/packages/plugins/Attributions/src/store/index.ts
@@ -43,7 +43,7 @@ const storeModule: PolarModule<AttributionsState, AttributionsGetters> = {
       dispatch('setAttributions')
 
       if (
-        typeof rootGetters?.configuration?.attributions?.initiallyOpen ===
+        typeof rootGetters.configuration?.attributions?.initiallyOpen ===
           'boolean' &&
         renderType === 'independent'
       ) {
@@ -74,17 +74,17 @@ const storeModule: PolarModule<AttributionsState, AttributionsGetters> = {
   getters: {
     ...generateSimpleGetters(getInitialState()),
     listenToChanges: (_, __, ___, rootGetters) =>
-      rootGetters?.configuration?.attributions?.listenToChanges || [],
+      rootGetters.configuration?.attributions?.listenToChanges || [],
     mapInfo: (_, { layer, attributions, staticAttributions }): string[] => {
       return lib.updateMapInfo(layer, attributions, staticAttributions)
     },
     renderType: (_, __, ___, rootGetters) =>
-      rootGetters?.configuration?.attributions?.renderType || 'independent',
+      rootGetters.configuration?.attributions?.renderType || 'independent',
     staticAttributions: (_, __, ___, rootGetters) => {
-      return rootGetters?.configuration?.attributions?.staticAttributions || []
+      return rootGetters.configuration?.attributions?.staticAttributions || []
     },
     windowWidth: (_, __, ___, rootGetters) =>
-      rootGetters?.configuration?.attributions?.windowWidth || 500,
+      rootGetters.configuration?.attributions?.windowWidth || 500,
   },
 }
 

--- a/packages/plugins/Draw/src/store/index.ts
+++ b/packages/plugins/Draw/src/store/index.ts
@@ -77,7 +77,7 @@ const storeModule: PolarModule<DrawState, DrawGetters> = {
       )
     },
     configuration(_, __, ___, rootGetters) {
-      return rootGetters?.configuration?.draw || {}
+      return rootGetters.configuration?.draw || {}
     },
     fontSizes(_, { configuration }) {
       const { textStyle } = configuration

--- a/packages/plugins/Fullscreen/src/store/index.ts
+++ b/packages/plugins/Fullscreen/src/store/index.ts
@@ -18,13 +18,13 @@ const storeModule: PolarModule<FullscreenState, FullscreenGetters> = {
   getters: {
     ...generateSimpleGetters(getInitialState()),
     renderType: (_, __, ___, rootGetters) => {
-      return rootGetters?.configuration?.fullscreen?.renderType
-        ? rootGetters?.configuration.fullscreen.renderType
+      return rootGetters.configuration?.fullscreen?.renderType
+        ? rootGetters.configuration.fullscreen.renderType
         : 'independent'
     },
     targetContainerId(_, __, ___, rootGetters) {
-      return rootGetters?.configuration?.fullscreen?.targetContainerId
-        ? rootGetters?.configuration?.fullscreen?.targetContainerId
+      return rootGetters.configuration?.fullscreen?.targetContainerId
+        ? rootGetters.configuration?.fullscreen?.targetContainerId
         : ''
     },
   },

--- a/packages/plugins/GeoLocation/src/store/getters.ts
+++ b/packages/plugins/GeoLocation/src/store/getters.ts
@@ -6,7 +6,7 @@ import getInitialState from './getInitialState'
 const getters: PolarGetterTree<GeoLocationState, GeoLocationGetters> = {
   ...generateSimpleGetters(getInitialState()),
   boundaryLayerId: (_, __, ___, rootGetters): string | undefined => {
-    return rootGetters?.configuration?.geoLocation?.boundaryLayerId
+    return rootGetters.configuration?.geoLocation?.boundaryLayerId
   },
   boundaryOnError: (_, __, ___, rootGetters) => {
     return (
@@ -14,15 +14,15 @@ const getters: PolarGetterTree<GeoLocationState, GeoLocationGetters> = {
     )
   },
   configuredEpsg: (_, __, ___, rootGetters): string | undefined => {
-    return rootGetters?.configuration?.epsg
+    return rootGetters.configuration?.epsg
   },
   checkLocationInitially: (_, __, ___, rootGetters): boolean => {
     return (
-      rootGetters?.configuration?.geoLocation?.checkLocationInitially || false
+      rootGetters.configuration?.geoLocation?.checkLocationInitially || false
     )
   },
   keepCentered: (_, __, ___, rootGetters): boolean => {
-    const keepCentered = rootGetters?.configuration?.geoLocation?.keepCentered
+    const keepCentered = rootGetters.configuration?.geoLocation?.keepCentered
     if (typeof keepCentered === 'boolean') {
       return keepCentered
     }
@@ -32,10 +32,10 @@ const getters: PolarGetterTree<GeoLocationState, GeoLocationGetters> = {
     return Boolean(rootGetters.configuration?.geoLocation?.showTooltip)
   },
   toastAction: (_, __, ___, rootGetters): string | undefined => {
-    return rootGetters?.configuration?.geoLocation?.toastAction
+    return rootGetters.configuration?.geoLocation?.toastAction
   },
   zoomLevel: (_, __, ___, rootGetters): number => {
-    return rootGetters?.configuration?.geoLocation?.zoomLevel || 7
+    return rootGetters.configuration?.geoLocation?.zoomLevel || 7
   },
   geoLocationMarkerLayer(_, __, ___, rootGetters) {
     return rootGetters?.map

--- a/packages/plugins/Gfi/src/store/getters.ts
+++ b/packages/plugins/Gfi/src/store/getters.ts
@@ -8,7 +8,7 @@ import getInitialState from './getInitialState'
 const getters: PolarGetterTree<GfiState, GfiGetters> = {
   ...generateSimpleGetters(getInitialState()),
   gfiConfiguration(_, __, ___, rootGetters): GfiConfiguration {
-    return <GfiConfiguration>(rootGetters?.configuration?.gfi || {
+    return <GfiConfiguration>(rootGetters.configuration?.gfi || {
       afterLoadFunction: null,
       coordinateSources: [],
       layers: {},

--- a/packages/plugins/IconMenu/src/store/index.ts
+++ b/packages/plugins/IconMenu/src/store/index.ts
@@ -18,7 +18,7 @@ const storeModule: PolarModule<IconMenuState, IconMenuState> = {
       const menus = rootGetters.configuration?.iconMenu?.menus || []
       const initializedMenus = menus
         .filter(({ id }) => {
-          const display = rootGetters?.configuration?.[id]?.displayComponent
+          const display = rootGetters.configuration?.[id]?.displayComponent
           return typeof display === 'boolean' ? display : true
         })
         .map((menu) => {

--- a/packages/plugins/Pins/src/store/index.ts
+++ b/packages/plugins/Pins/src/store/index.ts
@@ -266,7 +266,7 @@ const storeModule: PolarModule<PinsState, PinsState> = {
       coordinates: Coordinate
     ): Promise<boolean> {
       const { boundaryLayerId, toastAction, boundaryOnError } =
-        rootGetters?.configuration?.pins || {}
+        rootGetters.configuration?.pins || {}
 
       const boundaryCheckResult = await passesBoundaryCheck(
         rootGetters.map,

--- a/packages/plugins/Zoom/src/store/index.ts
+++ b/packages/plugins/Zoom/src/store/index.ts
@@ -58,13 +58,13 @@ const storeModule: PolarModule<ZoomState, ZoomGetters> = {
     minimumZoomLevelActive: (_, { zoomLevel, minimumZoomLevel }): boolean =>
       zoomLevel <= minimumZoomLevel,
     renderType: (_, __, ___, rootGetters) => {
-      return rootGetters?.configuration?.zoom?.renderType
-        ? rootGetters?.configuration.zoom.renderType
+      return rootGetters.configuration?.zoom?.renderType
+        ? rootGetters.configuration.zoom.renderType
         : 'independent'
     },
     showMobile: (_, __, ___, rootGetters) =>
-      typeof rootGetters?.configuration?.zoom?.showMobile === 'boolean'
-        ? rootGetters?.configuration.zoom.showMobile
+      typeof rootGetters.configuration?.zoom?.showMobile === 'boolean'
+        ? rootGetters.configuration.zoom.showMobile
         : false,
   },
 }


### PR DESCRIPTION
## Summary

The parameter `configuration` of the `core` store is always defined so optional chaining is not necessary.

## Instructions for local reproduction and review

If the pipeline succeeds, we are good to go

## Relevant tickets, issues, et cetera

\- / -
