### PR TITLE
Feature/meldemichel afm button

### DIFF
--- a/packages/clients/meldemichel/API.md
+++ b/packages/clients/meldemichel/API.md
@@ -84,7 +84,7 @@ A document rendering the map client could e.g. look like this:
         mapZoomLevel: 6,
         mapBaseLayer: 452,
         mapCenter: '566808.8386735287,5935896.23173797',
-        // NOTE: vendor_maps_address_to and -_plz are not read
+        // NOTE: vendor_maps_distance_to and -_plz are not read
       })
 
       // to retrieve map state updates, use this snippet:
@@ -99,7 +99,7 @@ A document rendering the map client could e.g. look like this:
           vendor_maps_address_hnr,
           vendor_maps_address_str,
           vendor_maps_address_plz,
-          vendor_maps_address_to
+          vendor_maps_distance_to
         }) => {
           // do anything with the map values here; example print
           console.info(`MapState Update
@@ -109,7 +109,7 @@ A document rendering the map client could e.g. look like this:
             Pin coordinate: ${vendor_maps_position}
             Address: ${vendor_maps_address_str + ' ' + vendor_maps_address_hnr}
             PLZ: ${vendor_maps_address_plz}
-            Distance to address: ${vendor_maps_address_to}`)
+            Distance to address: ${vendor_maps_distance_to}`)
         },
         // will return initial values; delete parameter if not desired
         { immediate: true }
@@ -138,7 +138,7 @@ Der URL werden folgende Query-Parameter (hier mit Beispielwerten) hinzugefügt:
 - `vendor_maps_address_str=Berlinertordamm`
 - `vendor_maps_address_hnr=4`
 - `vendor_maps_address_plz=12345`
-- `vendor_maps_address_to=0` (Entfernung zum Hit im Falle von )
+- `vendor_maps_distance_to=0` (Distanz zum Adresspunkt laut Reverse Geocoder)
 
 Analog liest der Klient im Modus `complete` beim Start auch alle bis auf die letzten zwei Query-Parameter wieder ein. Dabei wird die Adresse überschrieben, falls sie nicht zur `vendor_maps_position` passt.
 ```

--- a/packages/clients/meldemichel/CHANGELOG.md
+++ b/packages/clients/meldemichel/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Adding `AfmButton` for `COMPLETE` mode to open AfM process.
+- Fix: The listenable `mapState` field `vendor_maps_position` has been changed in its formatting. It now matches the formatting of the neighbouring `mapCenter` field (`number,number`) instead of being an array.
+- Fix: The listenable `mapState` field `vendor_maps_address_to` has been renamed to `vendor_maps_distance_to` to match the previous name.
+
 ## 1.0.0-alpaka.0
 
 Test release. Feature-complete for AfM integration.

--- a/packages/clients/meldemichel/src/html/index.html
+++ b/packages/clients/meldemichel/src/html/index.html
@@ -23,6 +23,8 @@
       client.createMap({
         containerId: 'polarstern',
         mode: 'COMPLETE',
+        // remove 'stage.' to link to productive service
+        afmUrl: `https://stage.afm.hamburg.de/intelliform/forms/mml_melde_michel/standard/mml_melde_michel/index`,
       })
     </script>
   </body>

--- a/packages/clients/meldemichel/src/index.html
+++ b/packages/clients/meldemichel/src/index.html
@@ -76,7 +76,7 @@
           vendor_maps_address_hnr,
           vendor_maps_address_str,
           vendor_maps_address_plz,
-          vendor_maps_address_to
+          vendor_maps_distance_to
         }) => {
           /* do anything with the map values here */
           console.info(`MapState Update
@@ -86,7 +86,7 @@
             Pin Coordinate: ${vendor_maps_position}
             Address: ${vendor_maps_address_str + ' ' + vendor_maps_address_hnr}
             PLZ: ${vendor_maps_address_plz}
-            Distance to address: ${vendor_maps_address_to}`)
+            Distance to address: ${vendor_maps_distance_to}`)
         },
         { immediate: true }
       )

--- a/packages/clients/meldemichel/src/language.ts
+++ b/packages/clients/meldemichel/src/language.ts
@@ -50,8 +50,6 @@ import { REPORT_STATUS, TIME_FILTER, SKAT } from './enums'
     'report.button.title': 'Einen neuen Schaden melden',
     'report.button.ariaDescription':
       'Öffnet eine neue Seite, auf welcher ein neues Anliegen gemeldet werden kann.',
-    'afmButton.noSearchedValue':
-      'Bitte geben Sie eine Hausnummer an oder wählen Sie eine Position durch Klick in die Karte.',
 */
 
 const language: LanguageOption[] = [

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -124,7 +124,7 @@ const geoLocation: Partial<GeoLocationConfiguration> = {
 }
 
 const mapConfigurations: Record<
-  string,
+  keyof typeof MODE,,
   (reportServiceId: string, afmUrl: string) => object
 > = {
   [MODE.COMPLETE]: (reportServiceId: string, afmUrl: string) => {

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -124,7 +124,7 @@ const geoLocation: Partial<GeoLocationConfiguration> = {
 }
 
 const mapConfigurations: Record<
-  keyof typeof MODE,,
+  keyof typeof MODE,
   (reportServiceId: string, afmUrl: string) => object
 > = {
   [MODE.COMPLETE]: (reportServiceId: string, afmUrl: string) => {
@@ -171,9 +171,11 @@ const mapConfigurations: Record<
       },
       pins: commonPins,
       reverseGeocoder,
-      meldemichelAfmButton: {
-        displayComponent: true,
-        afmUrl,
+      meldemichel: {
+        afmButton: {
+          displayComponent: true,
+          afmUrl,
+        },
       },
     }
   },

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -172,10 +172,7 @@ const mapConfigurations: Record<
       pins: commonPins,
       reverseGeocoder,
       meldemichel: {
-        afmButton: {
-          displayComponent: true,
-          afmUrl,
-        },
+        afmButton: { afmUrl },
       },
     }
   },

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -212,7 +212,7 @@ export const getMapConfiguration = ({
     )
   }
   return {
-    // @ts-expect-error | reportServiceId might be undefined, but that's catched above for relevant cases
+    // @ts-expect-error | reportServiceId might be undefined, but that's caught above for relevant cases
     ...mapConfigurations[mode](reportServiceId, afmUrl),
   }
 }

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -123,8 +123,11 @@ const geoLocation: Partial<GeoLocationConfiguration> = {
   showTooltip: true,
 }
 
-const mapConfigurations = {
-  [MODE.COMPLETE]: (reportServiceId: string) => {
+const mapConfigurations: Record<
+  string,
+  (reportServiceId: string, afmUrl: string) => object
+> = {
+  [MODE.COMPLETE]: (reportServiceId: string, afmUrl: string) => {
     return {
       ...commonMapConfiguration,
       addressSearch,
@@ -161,15 +164,17 @@ const mapConfigurations = {
             // TODO doesn't work atm; no coordinate source
             geometry: false,
             window: true,
-            properties: {
-              filename: 'Name of file',
-            },
+            properties: { filename: 'Name of file' },
           },
         },
         coordinateSources: [], // to be set in addPlugins.ts
       },
       pins: commonPins,
       reverseGeocoder,
+      meldemichelAfmButton: {
+        displayComponent: true,
+        afmUrl,
+      },
     }
   },
   [MODE.REPORT]: () => ({
@@ -195,8 +200,6 @@ const mapConfigurations = {
 
 export const getMapConfiguration = ({
   mode,
-  // NOTE temporarily commenting out, needed later in NeuesAnliegen-Plugin
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   afmUrl,
   reportServiceId,
 }: Pick<
@@ -208,13 +211,8 @@ export const getMapConfiguration = ({
       'POLAR Meldemichel Client: Missing reportServiceId configuration in mode COMPLETE.'
     )
   }
-  // @ts-expect-error | known issue; type definitions fit after merge in core
   return {
-    // @ts-expect-error | methods don't have a common interface
-    ...mapConfigurations[mode](reportServiceId),
-    // NOTE local plugin does not exist yet
-    // meldemichelNeuesAnliegen: {
-    //   afmUrl
-    // }
+    // @ts-expect-error | reportServiceId might be undefined, but that's catched above for relevant cases
+    ...mapConfigurations[mode](reportServiceId, afmUrl),
   }
 }

--- a/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
@@ -10,7 +10,7 @@
     @keydown.space="click"
   >
     <v-icon small>fa-map-location</v-icon>
-    {{ $t('common:plugins.meldemichelAfmButton.buttonText') }}
+    {{ $t('common:plugins.meldemichel.afmButton.buttonText') }}
   </v-btn>
 </template>
 
@@ -29,10 +29,10 @@ export default Vue.extend({
       )
     },
     afmUrl() {
-      const url = this.configuration.meldemichelAfmButton.afmUrl
+      const url = this.configuration.meldemichel.afmButton.afmUrl
       if (!url) {
         console.error(
-          'Missing afmUrl parameter in `configuration.meldemichelAfmButton.afmUrl`.'
+          'Missing afmUrl parameter in `configuration.meldemichel.afmButton.afmUrl`.'
         )
         return ''
       }
@@ -46,7 +46,7 @@ export default Vue.extend({
       if (!this.mapStateReady) {
         this.$store.dispatch('plugin/toast/addToast', {
           type: 'info',
-          text: 'plugins.meldemichelAfmButton.missingAddress',
+          text: 'plugins.meldemichel.afmButton.missingAddress',
           timeout: 10000,
         })
       }

--- a/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
@@ -7,6 +7,7 @@
     :href="mapStateReady ? afmUrl : '#'"
     large
     @click="click"
+    @keydown.space="click"
   >
     <v-icon small>fa-map-location</v-icon>
     {{ $t('common:plugins.meldemichelAfmButton.buttonText') }}

--- a/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
@@ -1,17 +1,24 @@
 <template>
-  <v-btn
-    v-if="afmUrl"
-    :target="mapStateReady ? '_blank' : ''"
-    color="primary"
-    class="meldemichel-afm-button"
-    :href="mapStateReady ? afmUrl : '#'"
-    large
-    @click="click"
-    @keydown.space="click"
-  >
-    <v-icon small>fa-map-location</v-icon>
-    {{ $t('common:plugins.meldemichel.afmButton.buttonText') }}
-  </v-btn>
+  <v-tooltip :left="!hasSmallWidth" :top="hasSmallWidth">
+    <template #activator="{ on, attrs }">
+      <v-btn
+        v-if="afmUrl"
+        :target="mapStateReady ? '_blank' : ''"
+        color="primary"
+        class="meldemichel-afm-button"
+        :href="mapStateReady ? afmUrl : '#'"
+        large
+        v-bind="attrs"
+        @click="click"
+        @keydown.space="click"
+        v-on="on"
+      >
+        <v-icon small>fa-map-location</v-icon>
+        {{ $t('common:plugins.meldemichel.afmButton.buttonText') }}
+      </v-btn>
+    </template>
+    <span>{{ $t('common:plugins.meldemichel.afmButton.hint') }}</span>
+  </v-tooltip>
 </template>
 
 <script lang="ts">
@@ -21,7 +28,7 @@ import { mapGetters } from 'vuex'
 export default Vue.extend({
   name: 'MeldemichelAfmButton',
   computed: {
-    ...mapGetters(['configuration']),
+    ...mapGetters(['configuration', 'hasSmallWidth']),
     ...mapGetters('meldemichel', ['mapState']),
     mapStateReady() {
       return Boolean(
@@ -59,6 +66,7 @@ export default Vue.extend({
 .meldemichel-afm-button {
   margin: 0 4px 4px 0;
   border: solid transparent;
+  pointer-events: initial;
 
   .v-btn__content {
     align-items: baseline;

--- a/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
@@ -15,7 +15,7 @@
 
 <script lang="ts">
 import Vue from 'vue'
-import { mapGetters, mapActions } from 'vuex'
+import { mapGetters } from 'vuex'
 
 export default Vue.extend({
   name: 'MeldemichelAfmButton',

--- a/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/AfmButton.vue
@@ -1,0 +1,70 @@
+<template>
+  <v-btn
+    v-if="afmUrl"
+    :target="mapStateReady ? '_blank' : ''"
+    color="primary"
+    class="meldemichel-afm-button"
+    :href="mapStateReady ? afmUrl : '#'"
+    large
+    @click="click"
+  >
+    <v-icon small>fa-map-location</v-icon>
+    {{ $t('common:plugins.meldemichelAfmButton.buttonText') }}
+  </v-btn>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+import { mapGetters, mapActions } from 'vuex'
+
+export default Vue.extend({
+  name: 'MeldemichelAfmButton',
+  computed: {
+    ...mapGetters(['configuration']),
+    ...mapGetters('meldemichel', ['mapState']),
+    mapStateReady() {
+      return Boolean(
+        this.mapState && !Object.values(this.mapState).includes(undefined)
+      )
+    },
+    afmUrl() {
+      const url = this.configuration.meldemichelAfmButton.afmUrl
+      if (!url) {
+        console.error(
+          'Missing afmUrl parameter in `configuration.meldemichelAfmButton.afmUrl`.'
+        )
+        return ''
+      }
+      return `${url}?${Object.entries(this.mapState)
+        .map(([key, value]) => `${key}=${value}`)
+        .join('&')}&charset=utf-8`
+    },
+  },
+  methods: {
+    click() {
+      if (!this.mapStateReady) {
+        this.$store.dispatch('plugin/toast/addToast', {
+          type: 'info',
+          text: 'plugins.meldemichelAfmButton.missingAddress',
+          timeout: 10000,
+        })
+      }
+    },
+  },
+})
+</script>
+
+<style lang="scss">
+.meldemichel-afm-button {
+  margin: 0 4px 4px 0;
+  border: solid transparent;
+
+  .v-btn__content {
+    align-items: baseline;
+
+    .v-icon {
+      margin-right: 0.5em;
+    }
+  }
+}
+</style>

--- a/packages/clients/meldemichel/src/plugins/AfmButton/index.ts
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/index.ts
@@ -5,7 +5,7 @@ import language from './language'
 
 export default (options: PluginOptions) => (instance: Vue) =>
   instance.$store.dispatch('addComponent', {
-    name: 'scale',
+    name: 'meldemichelAfmButton',
     plugin: AfmButton,
     language,
     options,

--- a/packages/clients/meldemichel/src/plugins/AfmButton/index.ts
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/index.ts
@@ -1,0 +1,12 @@
+import Vue from 'vue'
+import { PluginOptions } from '@polar/lib-custom-types'
+import AfmButton from './AfmButton.vue'
+import language from './language'
+
+export default (options: PluginOptions) => (instance: Vue) =>
+  instance.$store.dispatch('addComponent', {
+    name: 'scale',
+    plugin: AfmButton,
+    language,
+    options,
+  })

--- a/packages/clients/meldemichel/src/plugins/AfmButton/language.ts
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/language.ts
@@ -5,10 +5,12 @@ const language: LanguageOption[] = [
     type: 'de',
     resources: {
       plugins: {
-        meldemichelAfmButton: {
-          buttonText: 'Neues Anliegen',
-          missingAddress:
-            'Bitte geben Sie eine Adresse ein oder wählen Sie eine Position durch Klick in die Karte.',
+        meldemichel: {
+          afmButton: {
+            buttonText: 'Neues Anliegen',
+            missingAddress:
+              'Bitte geben Sie eine Adresse ein oder wählen Sie eine Position durch Klick in die Karte.',
+          },
         },
       },
     },

--- a/packages/clients/meldemichel/src/plugins/AfmButton/language.ts
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/language.ts
@@ -10,6 +10,7 @@ const language: LanguageOption[] = [
             buttonText: 'Neues Anliegen',
             missingAddress:
               'Bitte geben Sie eine Adresse ein oder wählen Sie eine Position durch Klick in die Karte.',
+            hint: 'Einen neuen Schaden melden',
           },
         },
       },

--- a/packages/clients/meldemichel/src/plugins/AfmButton/language.ts
+++ b/packages/clients/meldemichel/src/plugins/AfmButton/language.ts
@@ -1,0 +1,18 @@
+import { LanguageOption } from '@polar/lib-custom-types'
+
+const language: LanguageOption[] = [
+  {
+    type: 'de',
+    resources: {
+      plugins: {
+        meldemichelAfmButton: {
+          buttonText: 'Neues Anliegen',
+          missingAddress:
+            'Bitte geben Sie eine Adresse ein oder wählen Sie eine Position durch Klick in die Karte.',
+        },
+      },
+    },
+  },
+]
+
+export default language

--- a/packages/clients/meldemichel/src/polar-client.ts
+++ b/packages/clients/meldemichel/src/polar-client.ts
@@ -1,4 +1,4 @@
-import core from '@polar/core'
+import core, { NineLayoutTag } from '@polar/core'
 import merge from 'lodash.merge'
 import { Vector } from 'ol/layer'
 import { Map } from 'ol'
@@ -11,6 +11,7 @@ import { setBackgroundImage } from './utils/setBackgroundImage'
 import { MeldemichelCreateMapParams } from './types'
 import meldemichelModule from './store/module'
 import './styles/index.css'
+import AfmButton from './plugins/AfmButton'
 
 // eslint-disable-next-line no-console
 console.log(`POLAR Meldemichel loaded in version ${packageInfo.version}.`)
@@ -65,6 +66,14 @@ export default {
           })
 
           client.$store.registerModule('meldemichel', meldemichelModule)
+
+          if (mode === MODE.COMPLETE) {
+            // late setup due to dependency to meldemichelModule
+            AfmButton({
+              displayComponent: true,
+              layoutTag: NineLayoutTag.BOTTOM_RIGHT,
+            })(client)
+          }
 
           hideHamburgBorder(client.$store.getters.map)
           setBackgroundImage(containerId)

--- a/packages/clients/meldemichel/src/store/module.ts
+++ b/packages/clients/meldemichel/src/store/module.ts
@@ -14,7 +14,7 @@ interface SetMapStatePayload {
 
 interface GetMapState extends SetMapStatePayload {
   vendor_maps_address_plz: string
-  vendor_maps_address_to: number // distance between address and marker
+  vendor_maps_distance_to: number // distance between address and marker
 }
 
 export interface MeldemichelGetters {
@@ -97,13 +97,15 @@ const meldemichelModule: PolarModule<
         mapCenter: rootState.center?.join(',') || '',
         mapZoomLevel: rootState?.plugin?.zoom?.zoomLevel,
         mapBaseLayer: rootState?.plugin?.layerChooser?.activeBackgroundId,
-        vendor_maps_position: rootState?.plugin?.pins?.transformedCoordinate,
+        vendor_maps_position:
+          rootState?.plugin?.pins?.transformedCoordinate?.join?.(',') ||
+          undefined,
         vendor_maps_address_str: address?.properties?.Strasse,
         vendor_maps_address_hnr: address
           ? `${address.properties.Hausnr}${address.properties.Zusatz}`
           : undefined,
         vendor_maps_address_plz: address?.properties?.Plz,
-        vendor_maps_address_to: address?.properties?.Distanz,
+        vendor_maps_distance_to: address?.properties?.Distanz,
       }
     },
   },


### PR DESCRIPTION
## Summary

Add AfmButton that allows users to switch from map-only view to AfM reporting process.

## Instructions for local reproduction and review

Check in COMPLETE mode. Toasts when no address is chosen, and opens AfM reporting process when address is chosen. The AfM reporting process shows the address selected in the map, and going "Back" in the process produces the previous map view (regarding its center, size of client is different).