### PR TITLE
fix linebreak on ratio scale on narrow devices

### DIFF
--- a/packages/plugins/Scale/CHANGELOG.md
+++ b/packages/plugins/Scale/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Prevent linebreak on ratio scale on narrow devices.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/plugins/Scale/src/components/Scale.vue
+++ b/packages/plugins/Scale/src/components/Scale.vue
@@ -51,6 +51,7 @@ export default Vue.extend({
 
   .scale-as-a-ratio {
     display: inline-block;
+    white-space: nowrap;
     /* keeping border so texts align well */
     border-color: transparent;
 


### PR DESCRIPTION
## Summary

There were linebreaks here. They're gone now.

## Instructions for local reproduction and review

Test Meldemichel clients on local GitHub pages with mobile device, if need be.
