### PR TITLE
Add link to repository and license as required by EUPL v1.2

### DIFF
--- a/packages/plugins/Attributions/CHANGELOG.md
+++ b/packages/plugins/Attributions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Add link to repository and license as required by EUPL v1.2
+
 ## 1.0.0
 
 Initial release.

--- a/packages/plugins/Attributions/src/language.ts
+++ b/packages/plugins/Attributions/src/language.ts
@@ -10,6 +10,8 @@ const language: LanguageOption[] = [
             closeTitle: 'Quellennachweis ausblenden',
             openTitle: 'Quellennachweis einblenden',
           },
+          sourceCode:
+            '<span><a href="https://github.com/Dataport/polar" target="_blank">Quellcode</a> lizenziert unter <a href="https://github.com/Dataport/polar/blob/main/LICENSE" target="_blank">EUPL v1.2</a></span>',
         },
       },
     },
@@ -23,6 +25,8 @@ const language: LanguageOption[] = [
             closeTitle: 'Hide Attributions',
             openTitle: 'Show Attributions',
           },
+          sourceCode:
+            '<span><a href="https://github.com/Dataport/polar" target="_blank">Source code</a> licensed under <a href="https://github.com/Dataport/polar/blob/main/LICENSE" target="_blank">EUPL v1.2</a></span>',
         },
       },
     },

--- a/packages/plugins/Attributions/src/utils/lib.ts
+++ b/packages/plugins/Attributions/src/utils/lib.ts
@@ -51,6 +51,7 @@ function buildMapInfo(
     text.push(attribution.title)
   })
   staticAttributions.forEach((attribution) => text.push(attribution))
+  text.push('plugins.attributions.sourceCode')
   return text
 }
 

--- a/packages/plugins/Attributions/tests/attributions.spec.ts
+++ b/packages/plugins/Attributions/tests/attributions.spec.ts
@@ -27,25 +27,28 @@ describe('plugin-attributions', () => {
     describe('lib', () => {
       // TODO: Copy and adjust these tests to be usable with buildMapInfo as well
       describe('updateMapInfo', () => {
-        it('should return no Attributions if none are found', () => {
+        it('should return only the license information if no layer is found and no staticAttributions are given', () => {
           const mapInfo = updateMapInfo(['baz', 'foo'], mockyButions, [])
 
-          expect(mapInfo.length).toBe(0)
+          expect(mapInfo.length).toEqual(1)
+          expect(mapInfo[0]).toEqual('plugins.attributions.sourceCode')
         })
 
         it('should return configured attributions', () => {
           const mapInfo = updateMapInfo(['polarFuchs', 'foo'], mockyButions, [])
 
-          expect(mapInfo.length).toBe(1)
+          expect(mapInfo.length).toBe(2)
           expect(mapInfo[0]).toBe(mockyButions[3].title)
+          expect(mapInfo[1]).toEqual('plugins.attributions.sourceCode')
         })
 
         it('should return polarFuchs/PLN Attributions', () => {
           const mapInfo = updateMapInfo(['polarFuchs', 'PLN'], mockyButions, [])
 
-          expect(mapInfo.length).toBe(2)
+          expect(mapInfo.length).toBe(3)
           expect(mapInfo[0]).toBe(mockyButions[0].title)
           expect(mapInfo[1]).toBe(mockyButions[3].title)
+          expect(mapInfo[2]).toEqual('plugins.attributions.sourceCode')
         })
       })
     })


### PR DESCRIPTION
## Summary

As required by the EUPL license, a link as well as the license are always linked to when the attributions plugin is used.

## Instructions for local reproduction and review

Start any client and open the attributions. When using `snowbox`, the locale switch can be tested with #27 in mind.