### PR TITLE
Chore/package json links

### DIFF
--- a/packages/clients/afm/package.json
+++ b/packages/clients/afm/package.json
@@ -4,6 +4,12 @@
   "description": "Client Afm",
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "main": "./dist/afm.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/clients/afm"
+  },
   "files": [
     "dist/**/**.*",
     "docs/**/**.*",
@@ -12,7 +18,6 @@
     "CHANGELOG.md",
     "API.md"
   ],
-  "main": "./dist/afm.js",
   "scripts": {
     "postversion": "npm run build",
     "build": "rimraf dist && vite build && cd ../../.. && npm run docs:afm"

--- a/packages/clients/dish/package.json
+++ b/packages/clients/dish/package.json
@@ -4,6 +4,11 @@
   "description": "Client dish",
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/clients/dish"
+  },
   "files": [
     "dist/**/**.*",
     "CHANGELOG.md"

--- a/packages/clients/meldemichel/package.json
+++ b/packages/clients/meldemichel/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "dist/client-meldemichel.mjs",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/clients/meldemichel"
+  },
   "files": [
     "dist/**/**.*",
     "docs/**/**.*",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4,6 +4,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/components"
+  },
   "peerDependencies": {
     "vue": "^2.6.14"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/core"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.2.1",
     "@masterportal/masterportalapi": "2.8.0",

--- a/packages/lib/createTestMountParameters/package.json
+++ b/packages/lib/createTestMountParameters/package.json
@@ -4,6 +4,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/lib/createTestMountParameters"
+  },
   "devDependencies": {
     "@polar/lib-custom-types": "^1.0.0"
   }

--- a/packages/lib/getFeatures/package.json
+++ b/packages/lib/getFeatures/package.json
@@ -4,6 +4,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/lib/getFeatures"
+  },
   "peerDependencies": {
     "ol": "^7.1.0"
   }

--- a/packages/lib/idx/package.json
+++ b/packages/lib/idx/package.json
@@ -3,5 +3,10 @@
   "version": "1.0.0",
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
-  "main": "index.ts"
+  "main": "index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/lib/idx"
+  }
 }

--- a/packages/lib/passesBoundaryCheck/package.json
+++ b/packages/lib/passesBoundaryCheck/package.json
@@ -4,6 +4,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/lib/passesBoundaryCheck"
+  },
   "devDependencies": {
     "@polar/lib-custom-types": "^1.1.0"
   }

--- a/packages/plugins/AddressSearch/package.json
+++ b/packages/plugins/AddressSearch/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/AddressSearch"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Attributions/package.json
+++ b/packages/plugins/Attributions/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Attributions"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Draw/package.json
+++ b/packages/plugins/Draw/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Draw"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Export/package.json
+++ b/packages/plugins/Export/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Export"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Fullscreen/package.json
+++ b/packages/plugins/Fullscreen/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Fullscreen"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/GeoLocation/package.json
+++ b/packages/plugins/GeoLocation/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/GeoLocation"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Gfi/package.json
+++ b/packages/plugins/Gfi/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Gfi"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/IconMenu/package.json
+++ b/packages/plugins/IconMenu/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/IconMenu"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/LayerChooser/package.json
+++ b/packages/plugins/LayerChooser/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/LayerChooser"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Legend/package.json
+++ b/packages/plugins/Legend/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Legend"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/LoadingIndicator/package.json
+++ b/packages/plugins/LoadingIndicator/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/LoadingIndicator"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Pins/package.json
+++ b/packages/plugins/Pins/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Pins"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/ReverseGeocoder/package.json
+++ b/packages/plugins/ReverseGeocoder/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/ReverseGeocoder"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Scale/package.json
+++ b/packages/plugins/Scale/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Scale"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Toast/package.json
+++ b/packages/plugins/Toast/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Toast"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/plugins/Zoom/package.json
+++ b/packages/plugins/Zoom/package.json
@@ -5,6 +5,11 @@
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
   "main": "src/index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/plugins/Zoom"
+  },
   "files": [
     "src/**/*",
     "CHANGELOG.md"

--- a/packages/types/custom/package.json
+++ b/packages/types/custom/package.json
@@ -3,5 +3,10 @@
   "version": "1.1.0",
   "license": "EUPL-1.2",
   "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
-  "main": "index.ts"
+  "main": "index.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Dataport/polar.git",
+    "directory": "packages/types/custom"
+  }
 }


### PR DESCRIPTION
## Summary

Adding repository links to all package.json files. This way NPM will refer back to our GitHub repository.

No CHANGELOG entries have been made since I don't think we need patch releases for this. The links will be there eventually.