### PR TITLE
Fix map overlay being visible on desktop if map is not in focus

### DIFF
--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -148,21 +148,25 @@ export default Vue.extend({
         )
     },
     updateListeners(hasWindowSize: boolean) {
-      if (!hasWindowSize) {
-        document.addEventListener('wheel', ({ ctrlKey }) => {
-          clearTimeout(this.noControlOnZoomTimeout)
-          this.noControlOnZoom = !ctrlKey
-          this.noControlOnZoomTimeout = setTimeout(
-            () => (this.noControlOnZoom = false),
-            2000
-          )
-        })
+      const mapContainer = this.$refs['polar-map-container']
+      if (!hasWindowSize && mapContainer) {
+        ;(mapContainer as HTMLDivElement).addEventListener(
+          'wheel',
+          ({ ctrlKey }) => {
+            clearTimeout(this.noControlOnZoomTimeout)
+            this.noControlOnZoom = !ctrlKey
+            this.noControlOnZoomTimeout = setTimeout(
+              () => (this.noControlOnZoom = false),
+              2000
+            )
+          }
+        )
 
         if (
           window.innerHeight <= SMALL_DISPLAY_HEIGHT ||
           window.innerWidth <= SMALL_DISPLAY_WIDTH
         ) {
-          new Hammer(this.$refs['polar-map-container']).on('pan', (e) => {
+          new Hammer(mapContainer).on('pan', (e) => {
             this.oneFingerPan = e.maxPointers === 1
             setTimeout(() => (this.oneFingerPan = false), 2000)
           })


### PR DESCRIPTION
## Summary

Whenever the user focused on any element that was not the map, the map overlay was still being shown. This was especially annoying when scrolling the legend.

## Instructions for local reproduction and review

- `npm run snowbox`
- Open legend
- Scroll
- The overlay is not visible

One can now scroll on any part of the page other than the map and the overlay is only shown, once the cursor is actually on the `div` of the map.