### PR TITLE
fix listening documentation

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Feature: Add hovered and selected feature to vuex store. This is an optional functionality that has to be explicitly enabled and works with the `@masterportal/masterportalapi` default marker design. See configuration parameter `extendedMasterportalapiMarkers`.
 - Feature: Add zoomLevel as plugin-agnostic map information to store.
-- Chore: Adding README information about listening to map client state.
+- Chore: Add README information about listening to map client state and getters.
 
 ## 1.1.0
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature: Add hovered and selected feature to vuex store. This is an optional functionality that has to be explicitly enabled and works with the `@masterportal/masterportalapi` default marker design. See configuration parameter `extendedMasterportalapiMarkers`.
 - Feature: Add zoomLevel as plugin-agnostic map information to store.
+- Chore: Adding README information about listening to map client state.
 
 ## 1.1.0
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -184,9 +184,18 @@ The core module features a vuex root store that all plugin vuex modules are plug
 To ease use, the map instance also features a `subscribe` method that will register a watcher to any state field. Please mind that only documented paths should be used, and all others are subject to change without notice.
 
 ```js
+// state subscription – listening to data held by the map client
 map.subscribe('some/key', (value) => {
   // do something with the value
 })
+
+// getter subscription – these are computed values from various sources
+map.$store.watch(
+    (_, getters) => getters['some/key'],
+    (value) => {
+        // effect
+    }
+)
 ```
 
 This is, for example, useful to listen to search results, draw features, or marker coordinates. The plugins document how exactly to use their respective fields.

--- a/packages/plugins/AddressSearch/CHANGELOG.md
+++ b/packages/plugins/AddressSearch/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Feature: Change navigation of search results to use arrow keys instead of tabbing. If multiple groups are configured, the expand buttons can be navigated via arrow keys as well as tabbing. This should improve the usability for large result lists.
 - Feature: Add configuration parameter `focusAfterSearch` to be able to focus on the first result after a successful search.
 - Fix: Hide results if they are rendered as part of a group and the results exceed the configured limited amount.
+- Fix: Documentation error regarding plugin state.
 
 ## 1.0.0
 

--- a/packages/plugins/AddressSearch/README.md
+++ b/packages/plugins/AddressSearch/README.md
@@ -190,7 +190,7 @@ The payload object supports the following fields:
 | input      | string                         | Search string to be used.                                                                                                                                                                                                                         |
 | autoselect | enum['first', 'only', 'never'] | By default, 'never' is selected, and results will be presented as if the user searched for them. Setting 'only' will autoselect if a single result was returned; setting 'first' will autoselect the first of an arbitrary amount of results >=1. |
 
-### Getters
+### State
 
 ```js
 map.subscribe('plugin/addressSearch/chosenAddress', (chosenAddress) => {

--- a/packages/plugins/Draw/CHANGELOG.md
+++ b/packages/plugins/Draw/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Documentation error regarding plugin state.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/plugins/Draw/README.md
+++ b/packages/plugins/Draw/README.md
@@ -86,7 +86,7 @@ For the time being, please use this example as a rough reference as to what can 
 
 ## Store
 
-### Getters
+### State
 
 ```js
 map.subscribe('plugin/draw/featureCollection', (featureCollection) => {

--- a/packages/plugins/Export/CHANGELOG.md
+++ b/packages/plugins/Export/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Documentation error regarding plugin state.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/plugins/Export/README.md
+++ b/packages/plugins/Export/README.md
@@ -28,7 +28,7 @@ To programmatically trigger a "screenshot", use this action.
 map.$store.dispatch('plugin/export/exportAs', type)
 ```
 
-### Getters
+### State
 
 This shows how a callback can be used to immediately show a `Png` screenshot in an image tag. The value of the `screenshot` variable is a base64-encoded string.
 

--- a/packages/plugins/Fullscreen/CHANGELOG.md
+++ b/packages/plugins/Fullscreen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Documentation error regarding plugin state.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/plugins/Fullscreen/README.md
+++ b/packages/plugins/Fullscreen/README.md
@@ -15,7 +15,7 @@ The fullscreen plugin allows viewing the map in fullscreen mode. It relies solel
 
 ## Store
 
-### Getters
+### State
 
 ```js
 map.subscribe('plugin/fullscreen/isInFullscreen', (isInFullscreen) => {

--- a/packages/plugins/GeoLocation/CHANGELOG.md
+++ b/packages/plugins/GeoLocation/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unpublished
 
 - Feature: Add parameter `renderType` to configuration, allowing configuration as IconMenu subcomponent.
+- Fix: Documentation error regarding plugin state.
 
 ## 1.1.0
 

--- a/packages/plugins/GeoLocation/README.md
+++ b/packages/plugins/GeoLocation/README.md
@@ -34,7 +34,7 @@ either `true` or `false`. When a users denies the location tracking, the button 
 
 ## Store
 
-### Getters
+### State
 
 If the access to an users location has been granted, the coordinates get stored in the `position` state value. This value can be subscribed through the path `'plugin/geoLocation/position'`.
 

--- a/packages/plugins/Gfi/CHANGELOG.md
+++ b/packages/plugins/Gfi/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Feature: Added optional configuration parameter `activeLayerPath` to allow checking for whether any fitting layer is active.
 - Feature: Added support for type `GeoJSON` layers.
 - Fix: Add space to dev GFI window to fully contain close button effects.
+- Fix: Documentation error regarding plugin state.
 
 ## 1.0.0
 

--- a/packages/plugins/Gfi/README.md
+++ b/packages/plugins/Gfi/README.md
@@ -120,7 +120,7 @@ customHighlightStyle: {
 
 ## Store
 
-### Getters
+### State
 
 If a successful query has been sent and a response has been received, the result will be saved in the store and can be subscribed through the path `'plugin/gfi/featureInformation'`. If, however, a query for a layer fails, a `Symbol` containing the error will be saved in the store instead to indicate the error.
 

--- a/packages/plugins/LoadingIndicator/CHANGELOG.md
+++ b/packages/plugins/LoadingIndicator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Documentation error regarding plugin state/getters.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/plugins/LoadingIndicator/README.md
+++ b/packages/plugins/LoadingIndicator/README.md
@@ -34,7 +34,10 @@ You may desire to listen to whether the loader is currently being shown.
 | showLoader | boolean | Whether the layer is currently shown. |
 
 ```js
-map.subscribe('plugin/loadingIndicator/showLoader', (showLoader) => {
-  /* This code is called on showLoader updates. */
-})
+mapInstance.$store.watch(
+    (_, getters) => getters['plugin/loadingIndicator/showLoader'],
+    (showLoader) => {
+        /* This code is called on showLoader updates. */
+    }
+)
 ```

--- a/packages/plugins/Pins/CHANGELOG.md
+++ b/packages/plugins/Pins/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Feature: Add new configuration parameter `initial` to be able to add a pin initially to the map.
 - Feature: If `movable` is set to `none` or `false`, the style of the cursor is set to `not-allowed` when hovering the pin.
 - Fix: Mouse cursor wasn't `'grab'` from second created pin on. It now is on all movable pins.
+- Fix: Documentation error regarding plugin state.
 
 ## 1.0.0
 

--- a/packages/plugins/Pins/README.md
+++ b/packages/plugins/Pins/README.md
@@ -50,7 +50,7 @@ The usage of `displayComponent` has no influence on the creation of Pins on the 
 
 ## Store
 
-### Getters
+### State
 
 ```js
 map.subscribe('plugin/pins/transformedCoordinate', (pinCoordinate) => {

--- a/packages/plugins/Zoom/CHANGELOG.md
+++ b/packages/plugins/Zoom/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Documentation error regarding plugin state/getters.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/plugins/Zoom/README.md
+++ b/packages/plugins/Zoom/README.md
@@ -21,9 +21,10 @@ It can be configured as followed.
 |------------|------------------------------|-----------------------------------------------------------------------------------------------|
 | renderType | 'iconMenu' \| 'independent'? | Whether the zoom related buttons are being rendered independently or as part of the IconMenu. Defaults to 'independent'. |
 | showMobile | boolean?                     | Whether the zoom related buttons should be displayed on smaller devices; defaults to false.   |
+
 ## Store
 
-### Getters
+### State
 
 The map's zoom level can be listened to.
 
@@ -32,15 +33,27 @@ The map's zoom level can be listened to.
 | zoomLevel              | number  | Current OpenLayers zoom level.                |
 | maximumZoomLevel       | number  | Maximum OpenLayers zoom level.                |
 | minimumZoomLevel       | number  | Minimum OpenLayers zoom level.                |
-| maximumZoomLevelActive | boolean | Whether the current zoomLevel is the maximum. |
-| minimumZoomLevelActive | boolean | Whether the current zoomLevel is the minimum. |
-
-#### Usage example
 
 ```js
 map.subscribe('plugin/zoom/zoomLevel', (zoomLevel) => {
   /* This code is called on any zoomLevel update. */
 })
+```
+
+### Getters
+
+| fieldName | type | description |
+| - | - | - |
+| maximumZoomLevelActive | boolean | Whether the current zoomLevel is the maximum. |
+| minimumZoomLevelActive | boolean | Whether the current zoomLevel is the minimum. |
+
+```js
+mapInstance.$store.watch(
+  (_, getters) => getters['plugin/zoom/maximumZoomLevelActive'],
+  (maximumZoomLevelActive) => {
+    /* This code is called on value updates. */
+  }
+)
 ```
 
 ### Actions


### PR DESCRIPTION
There has been a mixup about state and getters in the plugin documentation. Since state and getters have to be listened to with deviating methods, a fix was in order.

Resolves: #37