### PR TITLE
hide fullscreen on iphone (not supported)

### DIFF
--- a/packages/plugins/Fullscreen/CHANGELOG.md
+++ b/packages/plugins/Fullscreen/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature: Hide obstructive tooltip on small devices.
 - Fix: Documentation error regarding plugin state.
+- Fix: Since iPhones do not support fullscreen mode, the fullscreen button is hidden on such devices.
 
 ## 1.0.0
 

--- a/packages/plugins/Fullscreen/src/components/Fullscreen.vue
+++ b/packages/plugins/Fullscreen/src/components/Fullscreen.vue
@@ -1,5 +1,6 @@
 <template>
   <v-tooltip
+    v-if="fullscreenAvailable"
     :left="!isHorizontal"
     :bottom="isHorizontal"
     :disabled="hasSmallDisplay"
@@ -56,6 +57,14 @@ export default Vue.extend({
         )
       }
       return this.$root.$el
+    },
+    fullscreenAvailable(): boolean {
+      return Boolean(
+        this.targetContainer &&
+          (this.targetContainer.requestFullscreen ||
+            // @ts-expect-error | 'TS2339: Property 'webkitRequestFullscreen' does not exist on type 'Element'.'; For information refer to https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#browser_compatibility
+            this.targetContainer.webkitRequestFullscreen)
+      )
     },
   },
   mounted() {


### PR DESCRIPTION
## Summary

The fullscreen button is hidden on iPhone devices (and other devices that do not support any of the used fullscreen methods).

This is due to Apple simply not supporting it on iPhone.

https://developer.mozilla.org/en-US/docs/Web/API/Fullscreen_API#browser_compatibility

## Instructions for local reproduction and review

Run the client in dev mode and check with any device.
