### PR TITLE
Update icons of layerChooser to be clearer for the content behind it

### DIFF
--- a/packages/clients/afm/CHANGELOG.md
+++ b/packages/clients/afm/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Update icon of `layerChooser` in `iconMenu` to `fa-layer-group` to clear-up the content hidden behind the menu button.
+
 ## 1.0.1
 
 - Fix: The included example files have been updated to the new syntax and work again.

--- a/packages/clients/afm/src/polar-client.ts
+++ b/packages/clients/afm/src/polar-client.ts
@@ -29,7 +29,7 @@ const iconMenu = PolarPluginIconMenu(
     menus: [
       {
         plugin: PolarPluginLayerChooser({}),
-        icon: 'fa-book-atlas',
+        icon: 'fa-layer-group',
         id: 'layerChooser',
       },
       {

--- a/packages/clients/dish/CHANGELOG.md
+++ b/packages/clients/dish/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Update icon of `layerChooser` in `iconMenu` to `fa-layer-group` to clear-up the content hidden behind the menu button.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/clients/dish/src/addPlugins.ts
+++ b/packages/clients/dish/src/addPlugins.ts
@@ -31,7 +31,7 @@ export const addPlugins = (core) => {
       menus: [
         {
           plugin: PolarPluginLayerChooser({}),
-          icon: 'fa-book-atlas',
+          icon: 'fa-layer-group',
           id: 'layerChooser',
         },
       ],

--- a/packages/clients/meldemichel/CHANGELOG.md
+++ b/packages/clients/meldemichel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Update icon of `layerChooser` in `iconMenu` to `fa-layer-group` to clear-up the content hidden behind the menu button.
+
 ## 1.0.0-beta.0
 
 Beta release. Feature-complete, but some known (and unknown?) bugs remain.

--- a/packages/clients/meldemichel/src/utils/createMenus.ts
+++ b/packages/clients/meldemichel/src/utils/createMenus.ts
@@ -12,7 +12,7 @@ export default function (mode: keyof typeof MODE): Menu[] {
   return [
     {
       plugin: LayerChooser({}),
-      icon: 'fa-book-atlas',
+      icon: 'fa-layer-group',
       id: 'layerChooser',
     },
     mode === MODE.COMPLETE && {

--- a/packages/clients/snowbox/src/addPlugins.ts
+++ b/packages/clients/snowbox/src/addPlugins.ts
@@ -29,7 +29,7 @@ export const addPlugins = (core) => {
     menus: [
       {
         plugin: LayerChooser({}),
-        icon: 'fa-book-atlas',
+        icon: 'fa-layer-group',
         id: 'layerChooser',
       },
       {


### PR DESCRIPTION
## Summary

After some feedback it became clear, that the previously used atlas icon needed to be replaced with a different icon.  
The decision fell on `layer-group` as it most closely resembles the usage one sees in e.g. Google Maps.

## Instructions for local reproduction and review

As all clients have been updated, all clients should be run and checked.