### PR TITLE
Refactor actionButton handling to fix gfi switch buttons issue

### DIFF
--- a/packages/clients/dish/src/plugins/Gfi/Content.vue
+++ b/packages/clients/dish/src/plugins/Gfi/Content.vue
@@ -114,10 +114,6 @@ export default Vue.extend({
       type: String,
       default: '',
     },
-    showSwitchButtons: {
-      type: Boolean,
-      default: false,
-    },
   },
   data: () => ({
     infoFields: [
@@ -133,7 +129,6 @@ export default Vue.extend({
   computed: {
     ...mapGetters(['hasSmallWidth', 'hasWindowSize']),
     ...mapGetters('plugin/gfi', [
-      'actionButton',
       'imageLoaded',
       'visibleWindowFeatureIndex',
       'windowFeatures',
@@ -176,18 +171,18 @@ export default Vue.extend({
   },
   mounted() {
     if (this.hasWindowSize && this.hasSmallWidth) {
-      this.setActionButton({
+      this.setMoveHandleActionButton({
         component: ActionButton,
         props: { exportProperty: this.exportProperty },
       })
     }
   },
   beforeDestroy() {
-    this.setActionButton(null)
+    this.setMoveHandleActionButton(null)
   },
   methods: {
+    ...mapMutations(['setMoveHandleActionButton']),
     ...mapMutations('plugin/gfi', [
-      'setActionButton',
       'setImageLoaded',
       'setVisibleWindowFeatureIndex',
     ]),

--- a/packages/clients/meldemichel/src/plugins/Gfi/Feature.vue
+++ b/packages/clients/meldemichel/src/plugins/Gfi/Feature.vue
@@ -85,20 +85,21 @@ export default Vue.extend({
     },
   },
   mounted() {
-    this.setActionButton({
+    this.setMoveHandleActionButton({
       component: ActionButtons,
       props: {},
     })
   },
   beforeDestroy() {
-    this.setActionButton(null)
+    this.setMoveHandleActionButton(null)
   },
   methods: {
+    ...mapMutations(['setMoveHandleActionButton']),
     ...mapMutations('plugin/gfi', [
-      'setActionButton',
       'setImageLoaded',
       'setVisibleWindowFeatureIndex',
     ]),
+    ...mapMutations(['setMoveHandle']),
     ...mapActions('plugin/gfi', ['close']),
     formatProperty(type: string, value: string): string {
       if (!value) {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Feature: A `renderFaToLightDom` parameter has been added. This can be used to disable rendering fontawesome styles to the Light/Root DOM. It is, by default, `true`.
 - Feature: A `stylePath` property has been added to the MapConfiguration. This is the new way to import the client CSS; the previous way with `data-polar="true"` has been deprecated. See README for details.
 - Feature: Add possibility to use the new slot added to `@polar/components` component `MoveHandle` to be able to use a different icon for the close-button.
+- Feature: Add possibility to directly add the action button to the component `MoveHandle` via the new state variable `moveHandleActionButton`.
 - Fix: POLAR now adds required Fontawesome styles to the Light/Root DOM. For more information, please check the `README.md` regarding `renderFaToLightDom`, which may also be used to disable this behaviour.
 
 ## 1.2.1

--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -27,10 +27,10 @@
       :close-label="moveHandle.closeLabel"
       :close-function="moveHandle.closeFunction"
     >
-      <template v-if="moveHandle.actionButton" #actionButton>
+      <template v-if="moveHandleActionButton" #actionButton>
         <component
-          :is="moveHandle.actionButton.component"
-          v-bind="moveHandle.actionButton.props"
+          :is="moveHandleActionButton.component"
+          v-bind="moveHandleActionButton.props"
         />
       </template>
       <template v-if="moveHandle.closeIcon" #closeIcon>
@@ -90,7 +90,12 @@ export default Vue.extend({
     oneFingerPanTimeout: undefined,
   }),
   computed: {
-    ...mapGetters(['hasSmallWidth', 'hasWindowSize', 'moveHandle']),
+    ...mapGetters([
+      'hasSmallWidth',
+      'hasWindowSize',
+      'moveHandle',
+      'moveHandleActionButton',
+    ]),
     renderMoveHandle() {
       return (
         this.moveHandle !== null && this.hasWindowSize && this.hasSmallWidth

--- a/packages/core/src/vuePlugins/vuex.ts
+++ b/packages/core/src/vuePlugins/vuex.ts
@@ -12,6 +12,7 @@ import noop from '@repositoryname/noop'
 import i18next from 'i18next'
 import {
   CoreState,
+  MoveHandleActionButton,
   MoveHandleProperties,
   PluginContainer,
   PolarError,
@@ -44,6 +45,7 @@ const devMode = import.meta.env.DEV
 let map: null | Map = null
 let hovered: null | Feature = null
 let moveHandle: MoveHandleProperties | null = null
+let moveHandleActionButton: MoveHandleActionButton | null = null
 let selected: null | Feature = null
 let components = []
 let interactions: Interaction[] = []
@@ -81,6 +83,7 @@ const getInitialState = (): CoreState => ({
   center: null,
   hovered: 1,
   moveHandle: 1,
+  moveHandleActionButton: 1,
   selected: 1,
   zoomLevel: 0,
   // TODO: Add default values for epsg, layers, namedProjections, options and remove @ts-ignore for configuration
@@ -118,6 +121,10 @@ const store = new Store({
     moveHandle: (state) => {
       noop(state.moveHandle)
       return moveHandle
+    },
+    moveHandleActionButton: (state) => {
+      noop(state.moveHandleActionButton)
+      return moveHandleActionButton
     },
     hovered: (state) => {
       noop(state.hovered)
@@ -171,6 +178,13 @@ const store = new Store({
     setMoveHandle: (state, payload: MoveHandleProperties | null) => {
       moveHandle = payload
       state.moveHandle += 1
+    },
+    setMoveHandleActionButton: (
+      state,
+      payload: MoveHandleActionButton | null
+    ) => {
+      moveHandleActionButton = payload
+      state.moveHandleActionButton += 1
     },
     setSelected: (state, payload) => {
       selected = payload

--- a/packages/lib/createTestMountParameters/CHANGELOG.md
+++ b/packages/lib/createTestMountParameters/CHANGELOG.md
@@ -1,5 +1,7 @@
 # CHANGELOG
 
+- Feature: Extend mock state to match current core state type.
+
 ## 1.1.0
 
 - Feature: Extend mock state to match current core state type.

--- a/packages/lib/createTestMountParameters/index.ts
+++ b/packages/lib/createTestMountParameters/index.ts
@@ -60,6 +60,7 @@ export default (): MockParameters => {
       errors: [],
       hasSmallDisplay: false,
       moveHandle: 0,
+      moveHandleActionButton: 0,
       plugin: {},
       language: '',
       zoomLevel: 0,

--- a/packages/plugins/Gfi/src/components/Gfi.vue
+++ b/packages/plugins/Gfi/src/components/Gfi.vue
@@ -27,7 +27,6 @@ export default Vue.extend({
   computed: {
     ...mapGetters(['moveHandle']),
     ...mapGetters('plugin/gfi', [
-      'actionButton',
       'exportPropertyLayerKeys',
       'gfiContentComponent',
       'gfiConfiguration',
@@ -84,9 +83,6 @@ export default Vue.extend({
         component: this.contentComponent,
         props: this.contentProps,
         plugin: this.renderType === 'independent' ? 'gfi' : 'iconMenu',
-      }
-      if (this.actionButton !== null) {
-        properties.actionButton = this.actionButton
       }
 
       return properties

--- a/packages/plugins/Gfi/src/store/getInitialState.ts
+++ b/packages/plugins/Gfi/src/store/getInitialState.ts
@@ -1,7 +1,6 @@
 import { GfiState } from '../types'
 
 const getInitialState = (): GfiState => ({
-  actionButton: null,
   featureInformation: {},
   imageLoaded: false,
   visibleWindowFeatureIndex: 0,

--- a/packages/plugins/Gfi/src/types.ts
+++ b/packages/plugins/Gfi/src/types.ts
@@ -12,7 +12,6 @@ import {
   GfiLayerConfiguration,
   RenderType,
   FeatureList,
-  MoveHandleActionButton,
 } from '@polar/lib-custom-types'
 
 /** parameter specification for request method */
@@ -29,7 +28,6 @@ export interface RequestGfiParameters {
 
 /** GFI Vuex Module State */
 export interface GfiState {
-  actionButton: MoveHandleActionButton | null
   /** default style for stroke and fill of the highlighted feature. */
   defaultHighlightStyle: HighlightStyle
   /** mapping of layer id to features found for last GFI call */

--- a/packages/types/custom/CHANGELOG.md
+++ b/packages/types/custom/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Feature: Add `stylePath` to `MapConfig` for a cleaner style import.
 - Feature: Add new parameter `closeIcon` to `MoveHandleProperties`.
+- Feature: Add `moveHandleActionButton` to `CoreGetters` and `CoreState` and remove it as the optional parameter `actionButton` from `MoveHandleProperties`.
 
 ## 1.2.0
 

--- a/packages/types/custom/core.ts
+++ b/packages/types/custom/core.ts
@@ -607,7 +607,6 @@ export interface MoveHandleProperties {
   component: Vue
   // Plugin that added the moveHandle
   plugin: string
-  actionButton?: MoveHandleActionButton
   closeIcon?: string
   props?: MoveHandleProps
 }
@@ -629,6 +628,7 @@ export interface CoreState {
   language: string
   map: number
   moveHandle: number
+  moveHandleActionButton: number
   plugin: object
   selected: number
   zoomLevel: number
@@ -645,6 +645,7 @@ export interface CoreGetters {
   errors: PolarError[]
   map: Map
   moveHandle: MoveHandleProperties
+  moveHandleActionButton: MoveHandleActionButton
   selected: Feature | null
   clientHeight: number
   clientWidth: number


### PR DESCRIPTION
## Summary

Resolves the issue of the switch buttons only appearing on the second click on a clustered feature.

## Instructions for local reproduction and review

Both clients should be tested on narrow and wide devices. Below instructions are for narrow devices.

- Meldemichel:
  - Search `Annenstraße` and choose the street
  - Zoom to maxZoom
  - Click on the remaining cluster
  - The switch buttons should be visible on first click
  - Click another feature, that is not a cluster
  - The switch buttons should be hidden
- DISH:
  - Click anywhere in the map where you suspect a feature
  - The export button should be shown in the top-left 

## Relevant tickets, issues, et cetera

Resolves #55