### PR TITLE
improve focus highlighting on WFS List

### DIFF
--- a/packages/plugins/Gfi/CHANGELOG.md
+++ b/packages/plugins/Gfi/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unpublished
 
+- Feature: Improve WFS list highlighting with focus/hover styles that are easier to decipher for end users.
 - Feature: Add the possibility to update the close-button to e.g. indicate movement to the vector layer feature list.
 
 ## 1.1.0

--- a/packages/plugins/Gfi/src/components/List.vue
+++ b/packages/plugins/Gfi/src/components/List.vue
@@ -180,12 +180,23 @@ export default Vue.extend({
 }
 
 .v-list-item {
-  /* reserved space so that hover outline works in FF */
-  margin-right: 2px;
+  &::before {
+    background: transparent;
+  }
+
+  // needed for FF
+  outline-offset: -2px;
+
+  &:hover {
+    outline: dashed 2px #3fa535;
+  }
+
+  &:focus {
+    outline: solid 2px #3fa535;
+  }
 }
 
 .gfi-feature-list-item-hovered {
-  outline: inset 2px #3fa535;
   background: #dff0dd;
 }
 </style>


### PR DESCRIPTION
## Summary

The focused feature is now highlighted with a solid border, the hovered with a dashed border, and map/neighbour focusing is indicated with a greenish background to the features.

This way, all states of highlighting should be easier to decipher for end users.

## Instructions for local reproduction and review

Visual check including mixed usage with keyboard and mouse on list and map.

## Relevant tickets, issues, et cetera

Resolves #67
Resolves #68