### PR TITLE
fix update attribution on leaving layer resolution

### DIFF
--- a/packages/plugins/Attributions/CHANGELOG.md
+++ b/packages/plugins/Attributions/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unpublished
 
 - Feature: Improved implementation to make plugin SPA-ready.
+- Fix: Update Attributions on zooming out of layer resolution boundaries.
 
 ## 1.1.0
 

--- a/packages/plugins/Attributions/src/store/index.ts
+++ b/packages/plugins/Attributions/src/store/index.ts
@@ -37,6 +37,7 @@ export const makeStoreModule = () => {
         layer.on('add', () => dispatch('setLayer'))
         layer.on('add', () => dispatch('setAttributions'))
         layer.on('change', () => dispatch('setLayer'))
+        map.on('moveend', () => dispatch('setLayer'))
 
         dispatch('setLayer')
         dispatch('setAttributions')


### PR DESCRIPTION
## Summary

See commit history.

## Instructions for local reproduction and review

Check whether scenario in issue now works. (shortcut: `npm run afm:dev`, open Attributions, zoom out)

## Relevant tickets, issues, et cetera

Resolves #5
