### PR TITLE
add missing aria label

### DIFF
--- a/packages/plugins/Fullscreen/CHANGELOG.md
+++ b/packages/plugins/Fullscreen/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Aria-label was missing on fullscreen button.
+
 ## 1.2.0
 
 - Feature: Improved implementation to make plugin SPA-ready.

--- a/packages/plugins/Fullscreen/src/components/Fullscreen.vue
+++ b/packages/plugins/Fullscreen/src/components/Fullscreen.vue
@@ -7,6 +7,11 @@
   >
     <template #activator="{ on, attrs }">
       <v-btn
+        :aria-label="
+          isInFullscreen
+            ? $t('common:plugins.fullscreen.button.tooltip.deactivate')
+            : $t('common:plugins.fullscreen.button.tooltip.activate')
+        "
         :class="{ 'ma-2': renderType === 'independent' }"
         color="primary"
         small


### PR DESCRIPTION
## Summary

An aria label was missing. It's there now.

## Instructions for local reproduction and review

Check with NVDA, if need be.