### PR TITLE
remove wildcard on street search

### DIFF
--- a/arcana.md
+++ b/arcana.md
@@ -15,5 +15,5 @@ For these cases, this not-so-secret file denotes our not-anymore-arcane knowledg
 
 ## Update process
 
-* Updating the `@masterportal/masterportalapi` requires a full test and API check in all using locations. The package does not follow SemVer, and thus it is up to us to make sure all endpoints fit appropriately.
+* Updating the `@masterportal/masterportalapi` requires a full test and API check in all using locations. The package does not follow SemVer, and thus it is up to us to make sure all endpoints fit appropriately. Also check the `scripts/overrideMasterportalapi.js`, which in the current version overrides the package's code to alter its behaviour.
 * Updating `ol` (which may implicitly happen on updating `@masterportal/masterportalapi`) should result in updating the version across all packages using it. Furthermore, use the search function to find all code positions with comments containing "undocumented". These code positions refer to `ol` functionality that is not documented and may change without a breaking version.

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "lint": "npx eslint . --cache --ext .js,.ts,.vue",
     "lint:ci": "npx eslint . --ext .js,.ts,.vue",
     "lint:fix": "npx eslint . --fix --cache --ext .js,.ts,.vue",
-    "postinstall": "lerna bootstrap --hoist",
+    "postinstall": "lerna bootstrap --hoist && node ./scripts/overrideMasterportalapi",
     "publishPackages": "node ./scripts/publishPackages",
     "test": "jest",
     "test:dev": "jest --coverage --coverageReporters=text --watchAll",

--- a/packages/clients/meldemichel/CHANGELOG.md
+++ b/packages/clients/meldemichel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: The gazetteer search returned confusing results. This was due to a wildcard option that allowed the return of imprecise matches. This has been deactivated since it tended to result in more confusion than it was helpful. The search now works as it does in the previous Meldemichel implementation.
+
 ## 1.0.0-beta.2
 
 - Feature: This client now supports the `@polar/core`'s field `stylePath`. The usage is documented in the API.md file.

--- a/scripts/overrideMasterportalapi.js
+++ b/scripts/overrideMasterportalapi.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+/*
+ * NOTE
+ *
+ * In current masterportalapi versions, this behaviour can be configured.
+ * Since it currently can't, we'll deactive the wildcard on street names. It
+ * may lead to notoriously bad results on an address search without further
+ * filtering, e.g. "Roonstraße" will first result in the "Liliencronstraße",
+ * which is about as confusing as it gets.
+ *
+ * On an update to the masterportalapi, we may make use of this by first
+ * running on the method without wildcard and, if no results came in, with
+ * wildcard.
+ */
+
+const fs = require('fs')
+
+const filePath =
+  './node_modules/@masterportal/masterportalapi/src/searchAddress/searchGazetteer.js'
+
+fs.readFile(filePath, { encoding: 'utf8' }, function (err, data) {
+  if (err) {
+    console.error(err)
+    process.exit(1)
+  }
+  const override = data.replaceAll('strassenname=*', 'strassenname=')
+  fs.writeFile(filePath, override, 'utf8', function (err) {
+    if (err) {
+      console.error(err)
+      process.exit(2)
+    }
+    console.log(
+      'The masterportalapi override was executed. (scripts/overrideMasterportalapi.js)'
+    )
+  })
+})


### PR DESCRIPTION
## Summary

See added file's `scripts/overrideMasterportalapi.js` for details. While this is a global change, I decided to document it in the Meldemichel, since it's the only client using this right now *and* the change results in a new Meldemichel beta release.

To save you the search, https://bitbucket.org/geowerkstatt-hamburg/masterportalapi/src/master/src/searchAddress/searchGazetteer.js is the file's current state. In case of masterportalapi update, we can do this properly.

## Instructions for local reproduction and review

Install (to trigger postinstall) and run the `client:meldemichel:dev`. Should the changes not arrive, it may be required to add `--force` to the vite command in the root package.json once to avoid vite's cache, which plausibly does not detect manual module changes.

An interesting search is for "Roonstraße". This produced plausible results in the previous Meldemichel (and on current /prod), but produces weird results on the /stage system ("Liliencronstraße").
