### PR TITLE
Fix keyboard navigation of address search

### DIFF
--- a/packages/plugins/AddressSearch/CHANGELOG.md
+++ b/packages/plugins/AddressSearch/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Keyboard navigation of results to work on all browsers.
+
 ## 1.2.0
 
 - Feature: Improved implementation to make plugin SPA-ready.

--- a/packages/plugins/AddressSearch/src/components/Results.vue
+++ b/packages/plugins/AddressSearch/src/components/Results.vue
@@ -151,14 +151,11 @@ export default Vue.extend({
     areResultsExpanded(category: string): boolean {
       return this.openCategories.includes(category)
     },
-    focusNextElement(
-      down: boolean,
-      { originalTarget }: { originalTarget: HTMLElement }
-    ): void {
+    focusNextElement(down: boolean, { target }: { target: HTMLElement }): void {
       const focus = ['BUTTON', 'LI']
       const sibling = down ? 'nextElementSibling' : 'previousElementSibling'
 
-      let searchBase: Element = originalTarget
+      let searchBase: Element = target
       let candidateElement: Element | null = searchBase[sibling]
 
       while (candidateElement && !focus.includes(candidateElement.tagName)) {


### PR DESCRIPTION
## Summary

Fixes the keyboard navigation not working on browsers other than Firefox as [originalTarget](https://developer.mozilla.org/en-US/docs/Web/API/Event/originalTarget) is non-standard.

## Instructions for local reproduction and review

Check meldemichel and dish if the keyboard navigation works in all kinds of browsers.
