### PR TITLE
improve robustness on misconfiguration

### DIFF
--- a/packages/plugins/LayerChooser/CHANGELOG.md
+++ b/packages/plugins/LayerChooser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: The LayerChooser plugin will keep working on the error that a layer without entry in the service register has been configured.
+
 ## 1.2.0
 
 - Feature: Improved implementation to make plugin SPA-ready.

--- a/packages/plugins/LayerChooser/src/store/index.ts
+++ b/packages/plugins/LayerChooser/src/store/index.ts
@@ -78,6 +78,14 @@ export const makeStoreModule = () => {
             id: layer.id,
           })
 
+          if (rawLayer === null) {
+            console.error(
+              `@polar/plugin-layer-chooser: Layer ${layer.id} not found in service register. This is a configuration issue. The map might behave in unexpected ways.`,
+              layer
+            )
+            return
+          }
+
           if (rawLayer.typ !== 'WMS' && !layer.hideInMenu) {
             console.warn(
               `@polar/plugin-layer-chooser: Used configuration 'layers' on layer with type '${

--- a/packages/plugins/Legend/CHANGELOG.md
+++ b/packages/plugins/Legend/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: The Legend plugin will keep working on the error that a layer without entry in the service register has been configured.
+
 ## 1.1.0
 
 - Feature: Locale string layer names are now translated.

--- a/packages/plugins/Legend/src/components/Legend.vue
+++ b/packages/plugins/Legend/src/components/Legend.vue
@@ -94,10 +94,19 @@ export default Vue.extend({
             id: layer.id,
           }),
         }))
-        .map((layer) => ({
-          ...layer,
-          legendUrl: masterportalapi.layerLib.getLegendURLs(layer.rawLayer)[0],
-        }))
+        .map((layer) => {
+          if (layer.rawLayer === null) {
+            // skip undefined layers
+            console.warn(`@polar/plugin-legend: Unknown layer.`, layer)
+            return {}
+          }
+          return {
+            ...layer,
+            legendUrl: masterportalapi.layerLib.getLegendURLs(
+              layer.rawLayer
+            )[0],
+          }
+        })
         .filter((layer) => layer.name && layer.legendUrl)
     },
   },


### PR DESCRIPTION
## Summary

Improve robustness for layer ids that are configured, but do not exist on the service registry.

## Instructions for local reproduction and review

Change any snowbox layer id to an id that does not exist and review client behaviour.