### PR TITLE
add noscript advisory

### DIFF
--- a/packages/clients/afm/API.md
+++ b/packages/clients/afm/API.md
@@ -38,7 +38,10 @@ In your HTML, a div with unique ID is required that holds the following style pr
     position: relative;
   "
   id="polarstern"
-/>
+>
+  <!-- Optional, may use if your page does not have its own <noscript> information -->
+  <noscript>Please use a browser with active JavaScript to use the map client.</noscript>
+</div>
 ```
 
 ```js

--- a/packages/clients/afm/example/index.html
+++ b/packages/clients/afm/example/index.html
@@ -34,7 +34,9 @@
         box-shadow: 0px 0px 5px 3px rgba(255, 255, 255, 0.5);
       "
       id="polarstern"
-    ></div>
+    >
+      <noscript>Bitte benutzen Sie einen Browser mit aktiviertem JavaScript, um den Kartenklienten zu nutzen.</noscript>
+    </div>
     <h2>Beispiel für programmatische Informationsbindung</h2>
     <p>Aktuelle Zoomstufe: <span id="vuex-target-zoom" /></p>
     <p>Featureinformationen: <span id="vuex-target-gfi" /></p>

--- a/packages/clients/afm/example/prod-example.html
+++ b/packages/clients/afm/example/prod-example.html
@@ -34,7 +34,9 @@
         box-shadow: 0px 0px 5px 3px rgba(255, 255, 255, 0.5);
       "
       id="polarstern"
-    ></div>
+    >
+      <noscript>Bitte benutzen Sie einen Browser mit aktiviertem JavaScript, um den Kartenklienten zu nutzen.</noscript>
+    </div>
     <h2>Beispiel für programmatische Informationsbindung</h2>
     <p>Aktuelle Zoomstufe: <span id="vuex-target-zoom" /></p>
     <p>Featureinformationen: <span id="vuex-target-gfi" /></p>

--- a/packages/clients/dish/src/index.html
+++ b/packages/clients/dish/src/index.html
@@ -20,7 +20,9 @@
   </head>
   <body style="width: 100%; height: 100%; overscroll-behavior: contain">
     <div style="width: 100%; height: 100%">
-      <div id="polarstern"></div>
+      <div id="polarstern">
+        <noscript>Bitte benutzen Sie einen Browser mit aktiviertem JavaScript, um den Kartenklienten zu nutzen.</noscript>
+      </div>
     </div>
     <script type="module" src="./polar-client.ts"></script>
   </body>

--- a/packages/clients/generic/API.md
+++ b/packages/clients/generic/API.md
@@ -20,6 +20,22 @@ The method expects a single object with the following parameters.
 | enabledPlugins  | string[]? | This is a client-specific field. Since the `@polar/client-generic` client contains all existing plugins, they are activated by strings. The strings match their package names: `'address-search' \| 'attributions' \| 'draw'* \| 'export' \| 'filter'* \| 'fullscreen'* \| 'geo-location'* \| 'gfi'* \| 'icon-menu' \| 'layer-chooser'* \| 'legend' \| 'loading-indicator' \| 'pins' \| 'reverse-geocoder' \| 'scale' \| 'toast' \| 'zoom'*`. The plugins marked with * are nested in the `'icon-menu'` in this pre-layouting, hence they depend upon it being active, too. |
 | modifyLayerConfiguration | ((layerConf: object[]) => object[])? | Defaults to identity function. This function is applied to the loaded layer configuration before usage. That is, the `services` can be modified by this to e.g. set parameters not supported by the service register, add additional layers, and so on. |
 
+In your HTML, a div with unique ID (`containerId` from above) is required that holds the following style properties. Width and height can be changed as you need, but are required to be defined.
+
+```html
+<div
+  style="
+    width: 680px;
+    height: 420px;
+    position: relative;
+  "
+  id="polarstern"
+>
+  <!-- Optional, may use if your page does not have its own <noscript> information -->
+  <noscript>Please use a browser with active JavaScript to use the map client.</noscript>
+</div>
+```
+
 `createMap` returns a Promise of a map instance. This returned instance is required to retrieve information from the map.
 
 The package also includes a `style.css` and an `index.html` file. The `style.css`'s relative path must, if it isn't the default value `'./style.css'`, be included in the `mapConfiguration` as follows:

--- a/packages/clients/meldemichel/API.md
+++ b/packages/clients/meldemichel/API.md
@@ -67,7 +67,10 @@ A document rendering the map client could e.g. look like this:
     </style>
   </head>
   <body>
-    <div id="meldemichel-map-client"></div>
+    <div id="meldemichel-map-client">
+      <!-- Optional, may use if your page does not have its own <noscript> information -->
+      <noscript>Please use a browser with active JavaScript to use the map client.</noscript>
+    </div>
     <script type="module">
       import meldemichelMapClient from './client-meldemichel.js'
 

--- a/packages/clients/meldemichel/src/html/index.html
+++ b/packages/clients/meldemichel/src/html/index.html
@@ -20,7 +20,9 @@
   </head>
   <body style="width: 100%; height: 100%; overscroll-behavior: contain">
     <div style="width: 100%; height: 100%">
-      <div id="polarstern"></div>
+      <div id="polarstern">
+        <noscript>Bitte benutzen Sie einen Browser mit aktiviertem JavaScript, um den Kartenklienten zu nutzen.</noscript>
+      </div>
     </div>
     <script type="module">
       import client from './client-meldemichel.js'

--- a/packages/clients/meldemichel/src/index.html
+++ b/packages/clients/meldemichel/src/index.html
@@ -21,7 +21,9 @@
   </head>
   <body style="width: 100%; height: 100%; overscroll-behavior: contain">
     <div style="width: 100%; height: 100%">
-      <div id="polarstern"></div>
+      <div id="polarstern">
+        <noscript>Bitte benutzen Sie einen Browser mit aktiviertem JavaScript, um den Kartenklienten zu nutzen.</noscript>
+      </div>
     </div>
     <script type="module">
       import client from './polar-client.ts'

--- a/packages/clients/snowbox/src/index.html
+++ b/packages/clients/snowbox/src/index.html
@@ -84,7 +84,9 @@
         <option value="de">German</option>
       </select>
     </label>
-    <div id="polarstern" class="polarstern"></div>
+    <div id="polarstern" class="polarstern">
+      <noscript>Please use a browser with active JavaScript to use the map client.</noscript>
+    </div>
     <h2>Example for programmatic information binding</h2>
     <p>
       This illustrates which kind of data can be retrieved from the map client.


### PR DESCRIPTION
## Summary

Add advisory to use noscript tag in POLAR's render div, should no other place on the page take care of this. No matter now noscript-compatible a page is, we are not.

## Instructions for local reproduction and review

Test whether `<noscript>` tag (added where possible) interfered with workflow.

I've skipped changelogs since no substantial changes have been made.

## Relevant tickets, issues, et cetera

Resolves: #104 