### PR TITLE
fix type to allow custom strings for custom methods

### DIFF
--- a/packages/types/custom/CHANGELOG.md
+++ b/packages/types/custom/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Add `string` as option for `SearchType` since arbitrary strings can be registered.
+
 ## 1.4.1
 
 - Fix: Increase type precision of EPSG codes from `string` to `EPSG:${string}`.

--- a/packages/types/custom/core.ts
+++ b/packages/types/custom/core.ts
@@ -35,7 +35,7 @@ export interface PluginOptions {
 export type RenderType = 'iconMenu' | 'independent'
 
 /** Possible search methods by type */
-export type SearchType = 'bkg' | 'gazetteer' | 'wfs' | 'mpapi'
+export type SearchType = 'bkg' | 'gazetteer' | 'wfs' | 'mpapi' | string
 
 /**
  * Additional queryParameters for the GET-Request;


### PR DESCRIPTION
## Summary

SearchType was previously hard-wired to pre-defined search types. However, since any client may add custom search methods, any string can be allowed as search type.

This allows `string` as search type for clients to use their own defined search methods without errors messages.
