### PR TITLE
add optional i18n for feature titles

### DIFF
--- a/packages/plugins/AddressSearch/CHANGELOG.md
+++ b/packages/plugins/AddressSearch/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Add title internationalization; i.e. features may now contain locale keys as titles.
+
 ## 1.2.1
 
 - Fix: Keyboard navigation of results to work on all browsers.

--- a/packages/plugins/AddressSearch/src/components/Results.vue
+++ b/packages/plugins/AddressSearch/src/components/Results.vue
@@ -55,7 +55,7 @@
         >
           <v-list-item-title>
             <!-- eslint-disable-next-line vue/no-v-html -->
-            <span v-html="emTitleByInput(feature.title, inputValue)"></span>
+            <span v-html="emTitleByInput($t(feature.title), inputValue)"></span>
           </v-list-item-title>
         </v-list-item>
       </template>


### PR DESCRIPTION
## Summary

Feature titles may now optionally hold locale keys. If the title is not found within the locales, it will be shown as-is.

No test environment given, will be used in the TextLocator.
