### PR TITLE
add vector source getter to draw plugin

### DIFF
--- a/packages/plugins/Draw/src/store/index.ts
+++ b/packages/plugins/Draw/src/store/index.ts
@@ -34,6 +34,9 @@ export const makeStoreModule = () => {
     actions,
     getters: {
       ...generateSimpleGetters(getInitialState()),
+      drawSource() {
+        return drawSource
+      },
       selectableDrawModes(_, { configuration }) {
         /* eslint-disable @typescript-eslint/naming-convention */
         // NOTE: Keys are directly used as technical keys for ol/interaction/Draw and are allowed to differ from the naming scheme.


### PR DESCRIPTION
## Summary

The vector source can now be fetched via getter, circumventing the previous necessity to dig it out from the map. The CHANGELOG was intentionally left unchanged as this is internal API only.
