### PR TITLE
Add AddressSearch and ReverseGeocoder to 'SINGLE' mode of meldemichel

### DIFF
--- a/packages/clients/meldemichel/CHANGELOG.md
+++ b/packages/clients/meldemichel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Add `@polar/plugin-address-search` and `@polar/plugin-reverse-geocoder` to mode `SINGLE`.
+
 ## 1.0.0-beta.5
 
 - Fix: Add missing API.md change. No further changes to previous version.

--- a/packages/clients/meldemichel/src/addPlugins.ts
+++ b/packages/clients/meldemichel/src/addPlugins.ts
@@ -27,7 +27,7 @@ export const addPlugins = (core, mode: keyof typeof MODE) => {
   core.addPlugins(
     [
       AddressSearch({
-        displayComponent: true,
+        displayComponent: mode !== MODE.SINGLE,
         layoutTag: NineLayoutTag.TOP_LEFT,
         addLoading: 'plugin/loadingIndicator/addLoadingKey',
         removeLoading: 'plugin/loadingIndicator/removeLoadingKey',

--- a/packages/clients/meldemichel/src/addPlugins.ts
+++ b/packages/clients/meldemichel/src/addPlugins.ts
@@ -26,13 +26,12 @@ export const addPlugins = (core, mode: keyof typeof MODE) => {
 
   core.addPlugins(
     [
-      mode !== MODE.SINGLE &&
-        AddressSearch({
-          displayComponent: true,
-          layoutTag: NineLayoutTag.TOP_LEFT,
-          addLoading: 'plugin/loadingIndicator/addLoadingKey',
-          removeLoading: 'plugin/loadingIndicator/removeLoadingKey',
-        }),
+      AddressSearch({
+        displayComponent: true,
+        layoutTag: NineLayoutTag.TOP_LEFT,
+        addLoading: 'plugin/loadingIndicator/addLoadingKey',
+        removeLoading: 'plugin/loadingIndicator/removeLoadingKey',
+      }),
       Pins({
         displayComponent: true,
         appearOnClick: { show: true, atZoomLevel: 0 },

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -248,11 +248,13 @@ const mapConfigurations: Record<
   }),
   [MODE.SINGLE]: () => ({
     ...commonMapConfiguration,
+    addressSearch: { ...addressSearch, displayComponent: false },
     layers: commonLayers,
     attributions: {
       ...commonAttributions,
     },
     pins: commonPins,
+    reverseGeocoder,
   }),
 }
 

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -248,7 +248,7 @@ const mapConfigurations: Record<
   }),
   [MODE.SINGLE]: () => ({
     ...commonMapConfiguration,
-    addressSearch: { ...addressSearch, displayComponent: false },
+    addressSearch,
     layers: commonLayers,
     attributions: {
       ...commonAttributions,


### PR DESCRIPTION
## Summary

It was requested that a feature can be reverse geocoded and the address search can be used programmatically in mode `SINGLE`.  
An addition to the API.md was redundant, as the programmatic usage has already been described in the README of `@polar/plugin-address-search`.

## Instructions for local reproduction and review

- Add the `mapInstance` to the `window` object in `packages/clients/meldemichel/example/single.html`.
- Use the following code snippet to trigger the search.

```js
window.$mapInstance.$store.dispatch('plugin/addressSearch/search', {
  input: 'Spitalerstraße 12',
  autoselect: 'first'
})
```

A pin should be set to `Spitalerstraße 12` and the following fields should have a value

- `vendor_maps_address_str`
- `vendor_maps_address_hnr`
- `vendor_maps_address_plz`
- `vendor_maps_distance_to`
