### PR TITLE
fix marker draggability after map size change

### DIFF
--- a/packages/plugins/Pins/CHANGELOG.md
+++ b/packages/plugins/Pins/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.1
+
+- Fix: The map dragged along with the pin in some situations, rendering the pin effectively immovable. This has been fixed.
+
 ## 1.3.0
 
 - Feature: Pins can now be re-initialized with the `setupInitial` action. This is an advanced feature currently only available when coding clients.

--- a/packages/plugins/Pins/src/store/getters.ts
+++ b/packages/plugins/Pins/src/store/getters.ts
@@ -1,0 +1,18 @@
+import { PolarGetterTree } from '@polar/lib-custom-types'
+import { generateSimpleGetters } from '@repositoryname/vuex-generators'
+import { PinsGetters, PinsState } from '../types'
+import { getInitialState } from './state'
+
+const getters: PolarGetterTree<PinsState, PinsGetters> = {
+  ...generateSimpleGetters(getInitialState()),
+  toZoomLevel(_, __, ___, rootGetters) {
+    return (rootGetters.configuration.pins || {}).toZoomLevel || 0
+  },
+  atZoomLevel(_, __, ___, rootGetters) {
+    return (
+      (rootGetters.configuration.pins || {}).appearOnClick?.atZoomLevel || 0
+    )
+  },
+}
+
+export default getters

--- a/packages/plugins/Pins/src/store/state.ts
+++ b/packages/plugins/Pins/src/store/state.ts
@@ -1,0 +1,9 @@
+import { PinsState } from '../types'
+
+export const getInitialState = (): PinsState => ({
+  isActive: false,
+  transformedCoordinate: [],
+  latLon: [],
+  coordinatesAfterDrag: [],
+  getsDragged: false,
+})

--- a/packages/plugins/Pins/src/types.ts
+++ b/packages/plugins/Pins/src/types.ts
@@ -4,6 +4,9 @@ export interface PinsState {
   latLon: number[]
   coordinatesAfterDrag: number[]
   getsDragged: boolean
+}
+
+export interface PinsGetters extends PinsState {
   toZoomLevel: number
   atZoomLevel: number
 }


### PR DESCRIPTION
## Summary

Oddly, the map would pan with the marker drag after switching to fullscreen mode, effectively rendering the marker almost immovable. This has been resolved by updating the Translate interaction on map size changes.

Since the file was of >300 lines size and the setup method was too long, I've refactored it while touching it. The actual fix is merely these lines:

```
        // without update, map will pan during drag
        this.watch(
          () => rootGetters.hasSmallWidth || rootGetters.hasSmallHeight,
          () => dispatch('updateMarkerDraggability')
        )
```

## Instructions for local reproduction and review

`npm run meldemichel:dev` with [index.zip](https://github.com/Dataport/polar/files/14601162/index.zip) used instead of the usual `index.html` in `meldemichel/src` to test the affected mode. Also testing the Pins plugin in other situations to make sure no unwanted side effects occur.
