### PR TITLE
Fix/plugin geo location no zoom outside extent

### DIFF
--- a/packages/clients/dish/CHANGELOG.md
+++ b/packages/clients/dish/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Add `toastAction` to `geoLocation` configuration.
+
 ## 1.1.1
 
 - Fix: The marker previously disappeared on being moved/reclicked on a second feature. This issue has been resolved.

--- a/packages/clients/dish/src/mapConfig.ts
+++ b/packages/clients/dish/src/mapConfig.ts
@@ -83,6 +83,7 @@ export const mapConfiguration = {
   },
   geoLocation: {
     checkLocationInitially: false,
+    toastAction: 'plugin/toast/addToast',
     zoomLevel: 7,
   },
   attributions: {

--- a/packages/plugins/GeoLocation/CHANGELOG.md
+++ b/packages/plugins/GeoLocation/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Only zoom to the user position if the user is currently in the extent of the map.
+
 ## 1.3.0
 
 - Feature: Improved implementation to make plugin SPA-ready.

--- a/packages/plugins/GeoLocation/src/store/actions.ts
+++ b/packages/plugins/GeoLocation/src/store/actions.ts
@@ -4,6 +4,7 @@ import VectorLayer from 'ol/layer/Vector'
 import Point from 'ol/geom/Point'
 import { Vector } from 'ol/source'
 import Feature from 'ol/Feature'
+import { containsCoordinate } from 'ol/extent'
 import { Style, Icon } from 'ol/style'
 import * as Proj from 'ol/proj.js'
 import Geolocation from 'ol/Geolocation.js'
@@ -130,11 +131,10 @@ const actions: PolarActionTree<GeoLocationState, GeoLocationGetters> = {
       configuredEpsg
     )
 
-    const boundaryCheckPassed = await passesBoundaryCheck(
-      map,
-      boundaryLayerId,
-      transformedCoords
-    )
+    const boundaryCheckPassed =
+      typeof boundaryLayerId === 'string'
+        ? await passesBoundaryCheck(map, boundaryLayerId, transformedCoords)
+        : containsCoordinate(map.getView().calculateExtent(), transformedCoords)
     const boundaryErrorOccurred = typeof boundaryCheckPassed === 'symbol'
 
     if (


### PR DESCRIPTION
## Summary

When using `@polar/plugin-geo-location`, the map tried to center on the users position even if they'd be outside of the maps extent. This behaviour has been fixed.

Note that the implementation could be combined with `@polar/lib-passes-boundary-check`. However, I didn't move forward with that as that would mean a breaking change in that package to optionalize the parameter `boundaryLayerId`.

## Instructions for local reproduction and review

Change the following parameter in `@polar/client-dish` and run the dev-Script

```json
startResolution: 10.583327618336419,
startCenter: [553655.72, 6004479.25],
extent: [
  562031.2360463801, 5993415.936589229, 578216.7556916607, 5993517.139659579,
],
```
