### PR TITLE
Change meldemichel to no longer focus on the first result

### DIFF
--- a/packages/clients/meldemichel/CHANGELOG.md
+++ b/packages/clients/meldemichel/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Change: The search now no longer focuses on the first result after a successful search.
+
 ## 1.0.0
 
 Initial release. 🎉

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -100,7 +100,6 @@ const addressSearch: AddressSearchConfiguration = {
   ],
   minLength: 3,
   waitMs: 300,
-  focusAfterSearch: true,
 }
 
 const commonPins: Partial<PinsConfiguration> = {


### PR DESCRIPTION
## Summary

As requested by the customer, `@polar/client-meldemichel` no longer focuses on the first result after a successful search.

## Instructions for local reproduction and review

`npm run meldemichel:dev`
