### PR TITLE
fix bugs in time frame filter

### DIFF
--- a/packages/plugins/Filter/CHANGELOG.md
+++ b/packages/plugins/Filter/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## unpublished
 
 - Fix: Configurations without time element could sometimes error on filtering operations.
+- Fix: Filtering by custom timeframe added an additional day into the range.
+- Fix: Filtering by a single day selected features of the next day only.
 
 ## 1.1.0
 

--- a/packages/plugins/Filter/src/utils/updateFeatureVisibility.ts
+++ b/packages/plugins/Filter/src/utils/updateFeatureVisibility.ts
@@ -22,7 +22,7 @@ const getFreeSelectionLimits = (clickLimits: Date[]): Date[] => {
     .sort()
     .map((x) => new Date(x))
   if (!limits[1]) {
-    limits[1] = limits[0]
+    limits[1] = new Date(limits[0])
   }
   return limits
 }
@@ -87,7 +87,7 @@ const doesFeaturePassTimeFilter = (
     limits[type === 'last' ? 1 : 0] = new Date(Date.now())
   }
   limits[0].setHours(0, 0, 0, 0)
-  limits[1].setHours(24, 0, 0, 0)
+  limits[1].setHours(23, 59, 59, 999)
 
   return limits[0] <= featureDate && featureDate <= limits[1]
 }
@@ -150,6 +150,7 @@ export const updateFeatureVisibility = ({
     .flat(1)
   // only update finally to prevent overly recalculating clusters
   source.clear()
+
   updateFeatures.forEach((feature) => {
     const targetStyle = doesFeaturePassFilter(
       feature,


### PR DESCRIPTION
## Summary

- Selecting a single day filtered features in a way that selected only the day after the day selected.
- Selecting a date range added another day at the end.

These issues have been resolved.

## Instructions for local reproduction and review

This fix can easily be tested in `npm run meldemichel:dev` since features denote their date in GFI and the filter is configured.
