### PR TITLE
fix GeoLocation failing map init on Safari<16

### DIFF
--- a/packages/plugins/GeoLocation/CHANGELOG.md
+++ b/packages/plugins/GeoLocation/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unpublished
 
 - Fix: Only zoom to the user position if the user is currently in the extent of the map. The user position is no longer indicated when it's outside the map's extent.
+- Fix: The plugin would fail the map initialization procedure on Safari 15 and prior. This issue has been resolved by disabling the fail-fast feature for browsers not supporting `navigator.permissions.query`.
 
 ## 1.3.0
 

--- a/packages/plugins/GeoLocation/src/store/actions.ts
+++ b/packages/plugins/GeoLocation/src/store/actions.ts
@@ -18,12 +18,14 @@ const actions: PolarActionTree<GeoLocationState, GeoLocationGetters> = {
   setupModule({ getters, commit, dispatch }): void {
     dispatch('addMarkerLayer')
 
-    // NOTE: limited support across browsers
-    navigator.permissions.query({ name: 'geolocation' }).then((result) => {
-      if (result.state === 'denied') {
-        commit('setIsGeolocationDenied', true)
-      }
-    })
+    // NOTE: limited support across browsers; nice but optional initially
+    if (navigator.permissions?.query) {
+      navigator.permissions.query({ name: 'geolocation' }).then((result) => {
+        if (result.state === 'denied') {
+          commit('setIsGeolocationDenied', true)
+        }
+      })
+    }
     if (getters.checkLocationInitially) {
       dispatch('track')
     }


### PR DESCRIPTION
## Summary

Fix the GeoLocation plugin that accessed `navigator.permissions.query` without checking whether it's supported prior, resulting in a failure of the map initialization on Safari versions below 16 and some other browsers.

## Instructions for local reproduction and review

This can be tested in the Meldemichel on a device with Safari<16. Since the map will not request access to the geolocation feature initially, it will simply proceed to try and fetch the geolocation; this triggers the usual request and will lead to an error toast.
