### PR TITLE
fix filter plugin inconsistencies

### DIFF
--- a/packages/plugins/Filter/CHANGELOG.md
+++ b/packages/plugins/Filter/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 1.1.2
+
+- Fix: Features with categories that are not listed in `knownValues` are never displayed now. Previously, they were initially visible, but disappeared once any filter was touched.
+- Fix: It was possible to have features visible that were loaded after the filter was applied and that would have been filtered out. This has been resolved.
+
 ## 1.1.1
 
 - Fix: Configurations without time element could sometimes error on filtering operations.

--- a/packages/plugins/Filter/README.md
+++ b/packages/plugins/Filter/README.md
@@ -28,7 +28,7 @@ The following chapters contain drafts in this format. Please mind that they neit
 | fieldName | type | description |
 | - | - | - |
 | targetProperty | string | Target property to filter by. This is the name (that is, key) of a feature property. |
-| knownValues | (string \| number \| boolean \| null)[] | Array of known values for the feature properties. Each entry will result in a checkbox that allows filtering the appropriate features. Properties not listed will not be filterable. The technical name will result in a localization key that can be configured on a per-client basis. |
+| knownValues | (string \| number \| boolean \| null)[] | Array of known values for the feature properties. Each entry will result in a checkbox that allows filtering the appropriate features. Properties not listed will not be filterable and never be visible. The technical name will result in a localization key that can be configured on a per-client basis. |
 | selectAll | boolean? | If true, a checkbox is added to de/select all `knownValues` (above) at once. Defaults to `false`. |
 
 For example, `{targetProperty: 'favouriteIceCream', knownValues: ['chocolate', 'vanilla', 'strawberry'], selectAll: true}` will add these checkboxes:

--- a/packages/plugins/Filter/src/utils/updateFeatureVisibility.ts
+++ b/packages/plugins/Filter/src/utils/updateFeatureVisibility.ts
@@ -111,7 +111,7 @@ const doesFeaturePassFilter = (
   )
 }
 
-const getLayer = (map: Map, layerId: LayerId): BaseLayer => {
+export const getLayer = (map: Map, layerId: LayerId): BaseLayer => {
   const layer = map
     .getLayers()
     .getArray()


### PR DESCRIPTION
## Summary

The filter is now applied initially and on layer loads to prevent inconsistent/confusing UI states. Previously, never-visible features were visible initially, and newly loaded features would not have been filtered correctly. (Albeit there's no known client that has the latter issue at the time being, since all currently known clients are using the filter on initially completely loaded WFS.)

The README has been clarified regarding this.

## Instructions for local reproduction and review

Check the behaviour in the Meldemichel. Initially, less features should be visible than are transported via network. (See current count in anliegen_extern.json, it's constantly changing.)
