### PR TITLE
Fix incorrect link on documentation page linking to plugin gallery

### DIFF
--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -154,7 +154,7 @@ client.createMap({
         </li>
       </ul>
 
-      <p>And that's about it. For more examples, view the <a href="http://127.0.0.1:8080/index.html#plugin-gallery" target="_blank">plugin gallery ↗</a> or choose a specific client's documentation files.</p>
+      <p>And that's about it. For more examples, view the <a href="https://dataport.github.io/polar/#plugin-gallery" target="_blank">plugin gallery ↗</a> or choose a specific client's documentation files.</p>
     </article>
     <hr>
     <article id="development">


### PR DESCRIPTION
## Summary

On https://dataport.github.io/polar/documentation.html the link to the plugin gallery was incorrect. This has been fixed.

## Instructions for local reproduction and review

Check whether the new link is correct.