### PR TITLE
update @polar/core dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "polar-monorepo",
       "license": "EUPL-1.2",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.2.1",
+        "@fortawesome/fontawesome-free": "^6.5.2",
         "@masterportal/masterportalapi": "2.8.0",
         "@repositoryname/noop": "^1.0.6",
         "@repositoryname/vuex-generators": "^1.1.2",
@@ -15,8 +15,8 @@
         "@turf/union": "^6.5.0",
         "focus-trap": "^7.2.0",
         "hammerjs": "2.0.8",
-        "i18next": "^23.7.16",
-        "i18next-browser-languagedetector": "^7.2.0",
+        "i18next": "^23.11.5",
+        "i18next-browser-languagedetector": "^8.0.0",
         "i18next-vue": "^1.1.0",
         "js-levenshtein": "^1.1.6",
         "jspdf": "^2.4.0",
@@ -25,8 +25,8 @@
         "lodash.kebabcase": "^4.1.1",
         "lodash.mapvalues": "^4.6.0",
         "olcs": "2.13.1",
-        "vue": "^2.6.14",
-        "vuetify": "^2.5.9",
+        "vue": "^2.7.16",
+        "vuetify": "^2.7.2",
         "vuex": "^3.6.2"
       },
       "devDependencies": {
@@ -11877,9 +11877,9 @@
       }
     },
     "node_modules/i18next-browser-languagedetector": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.1.tgz",
-      "integrity": "sha512-h/pM34bcH6tbz8WgGXcmWauNpQupCGr25XPp9cZwZInR9XHSjIFDYp1SIok7zSPsTOMxdvuLyu86V+g2Kycnfw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.0.tgz",
+      "integrity": "sha512-zhXdJXTTCoG39QsrOCiOabnWj2jecouOqbchu3EfhtSHxIB5Uugnm9JaizenOy39h7ne3+fLikIjeW88+rgszw==",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
       }
@@ -14929,9 +14929,9 @@
       }
     },
     "node_modules/jspdf/node_modules/dompurify": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.5.tgz",
-      "integrity": "sha512-FgbqnEPiv5Vdtwt6Mxl7XSylttCC03cqP5ldNT2z+Kj0nLxPHJH4+1Cyf5Jasxhw93Rl4Oo11qRoUV72fmya2Q==",
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.6.tgz",
+      "integrity": "sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==",
       "optional": true
     },
     "node_modules/just-compare": {
@@ -31522,9 +31522,9 @@
       }
     },
     "i18next-browser-languagedetector": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.1.tgz",
-      "integrity": "sha512-h/pM34bcH6tbz8WgGXcmWauNpQupCGr25XPp9cZwZInR9XHSjIFDYp1SIok7zSPsTOMxdvuLyu86V+g2Kycnfw==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.0.0.tgz",
+      "integrity": "sha512-zhXdJXTTCoG39QsrOCiOabnWj2jecouOqbchu3EfhtSHxIB5Uugnm9JaizenOy39h7ne3+fLikIjeW88+rgszw==",
       "requires": {
         "@babel/runtime": "^7.23.2"
       }
@@ -33771,9 +33771,9 @@
       },
       "dependencies": {
         "dompurify": {
-          "version": "2.5.5",
-          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.5.tgz",
-          "integrity": "sha512-FgbqnEPiv5Vdtwt6Mxl7XSylttCC03cqP5ldNT2z+Kj0nLxPHJH4+1Cyf5Jasxhw93Rl4Oo11qRoUV72fmya2Q==",
+          "version": "2.5.6",
+          "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.6.tgz",
+          "integrity": "sha512-zUTaUBO8pY4+iJMPE1B9XlO2tXVYIcEA4SNGtvDELzTSCQO7RzH+j7S180BmhmJId78lqGU2z19vgVx2Sxs/PQ==",
           "optional": true
         }
       }

--- a/packages/clients/textLocator/src/utils/literatureByToponym.ts
+++ b/packages/clients/textLocator/src/utils/literatureByToponym.ts
@@ -28,5 +28,6 @@ export async function searchLiteratureByToponym(
       body: `{"location_names":${JSON.stringify(names)}}`,
     }
   )
-  return (await response.json()).title_location_freq as TitleLocationFrequency
+  return ((await response.json()).title_location_freq ||
+    {}) as TitleLocationFrequency
 }

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Feature: Add new state parameter `mapHasDimensions` to let plugins have a "hook" to react on when the map is ready.
 - Feature: Add `deviceIsHorizontal` as a getter to have a more central place to check if the device is in landscape mode.
 - Fix: Adjust documentation to properly describe optionality of configuration parameters.
+- Chore: Updated dependencies to latest versions.
 
 ## 1.4.1
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Feature: Add new state parameter `mapHasDimensions` to let plugins have a "hook" to react on when the map is ready.
 - Feature: Add `deviceIsHorizontal` as a getter to have a more central place to check if the device is in landscape mode.
 - Fix: Adjust documentation to properly describe optionality of configuration parameters.
-- Chore: Updated dependencies to latest versions.
+- Chore: Update dependencies to latest versions.
 
 ## 1.4.1
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,7 +12,7 @@
     "directory": "packages/core"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^6.2.1",
+    "@fortawesome/fontawesome-free": "^6.5.2",
     "@masterportal/masterportalapi": "2.8.0",
     "@polar/components": "^2.0.0",
     "@polar/lib-idx": "^1.0.0",
@@ -21,14 +21,14 @@
     "@repositoryname/noop": "^1.0.6",
     "@repositoryname/vuex-generators": "^1.1.2",
     "hammerjs": "2.0.8",
-    "i18next": "^23.7.16",
-    "i18next-browser-languagedetector": "^7.2.0",
+    "i18next": "^23.11.5",
+    "i18next-browser-languagedetector": "^8.0.0",
     "i18next-vue": "^1.1.0",
     "lodash.merge": "^4.6.2",
     "lodash.kebabcase": "^4.1.1",
     "olcs": "2.13.1",
-    "vue": "^2.6.14",
-    "vuetify": "^2.5.9",
+    "vue": "^2.7.16",
+    "vuetify": "^2.7.2",
     "vuex": "^3.6.2"
   },
   "peerDependencies": {

--- a/packages/lib/tooltip/package.json
+++ b/packages/lib/tooltip/package.json
@@ -11,6 +11,6 @@
     "directory": "packages/lib/tooltip"
   },
   "peerDependencies": {
-    "i18next": "^21.6.0"
+    "i18next": "^23.x"
   }
 }

--- a/packages/plugins/Scale/package.json
+++ b/packages/plugins/Scale/package.json
@@ -17,7 +17,7 @@
   ],
   "peerDependencies": {
     "@repositoryname/vuex-generators": "^1.1.2",
-    "i18next": "^21.6.0",
+    "i18next": "^23.x",
     "ol": "^7.1.0",
     "vue": "^2.6.14",
     "vuex": "^3.6.2"


### PR DESCRIPTION
## Summary

All @polar/core dependencies have been updated where updates, where compatible with our Vue@2 setup.

## Instructions for local reproduction and review

No breaking change affected us, and most dependencies were implicitly already installed in the version noted now. Clients can be arbitrarily tested for i18n still working, which was the only breaking change.
