### PR TITLE
POLAR-326 Remove whitespaces from tables within Readme-files

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -69,14 +69,14 @@ MapClient.createMap({
 
 The mapConfiguration allows controlling many client instance details.
 
-| fieldName                   | type             | description                                                                                                                                                              |
+| fieldName | type | description |
 | --------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| layerConf                   | LayerConf        | Layer configuration as required by masterportalAPI.                                                                                                                      |
-| language                    | enum["de", "en"] | Initial language.                                                                                           |
-| <...masterportalAPI.fields> | various          | The object is also used to initialize the masterportalAPI. Please refer to their documentation for options.                                                              |
-| <plugin.fields>             | various?          | Many plugins added with `addPlugin` may respect additional configuration. Please see the respective plugin documentations. Global plugin parameters are described below. |
+| layerConf | LayerConf | Layer configuration as required by masterportalAPI. |
+| language | enum["de", "en"] | Initial language. |
+| <...masterportalAPI.fields> | various | The object is also used to initialize the masterportalAPI. Please refer to their documentation for options. |
+| <plugin.fields> | various? | Many plugins added with `addPlugin` may respect additional configuration. Please see the respective plugin documentations. Global plugin parameters are described below. |
 | locales | LanguageOption[]? | All locales in POLAR's plugins can be overridden to fit your needs.|
-| vuetify                     | object?           | You may add vuetify configuration here.                                                                                                                                  |
+| vuetify | object? | You may add vuetify configuration here. |
 | extendedMasterportalapiMarkers | extendedMasterportalapiMarkers? | Optional. If set, all configured visible vector layers' features can be hovered and selected by mouseover and click respectively. They are available as features in the store. Layers with `clusterDistance` will be clustered to a multi-marker that supports the same features. Please mind that this only works properly if you configure nothing but point marker vector layers styled by the masterportalAPI. |
 | stylePath | string? | If no link tag with `data-polar="true"` is found in the document, this path will be used to create the link node in the client itself. It defaults to `'./style.css'`. Please mind that `data-polar="true"` is deprecated since it potentially led to flashes of misstyled content. stylePath will replace that solution in the next major release. |
 | renderFaToLightDom | boolean? | POLAR requires FontAwesome in the Light/Root DOM due to an [unfixed bug in many browsers](https://bugs.chromium.org/p/chromium/issues/detail?id=336876). This value defaults to `true`. POLAR will, by default, just add the required CSS by itself. Should you have a version of Fontawesome already included, you can try to set this to `false` to check whether the versions are interoperable. |

--- a/packages/lib/testMountParameters/README.md
+++ b/packages/lib/testMountParameters/README.md
@@ -1,4 +1,4 @@
 # createTestMountParameters
 
-This is a helper function for vue testing. It returns fresh `MockParameters`, including a `localVue`, `vuetify`, and `vuex` instance, the latter copying the basic `core` store structure, i.e., having an empty namespaced `plugin` module.  
+This is a helper function for vue testing. It returns fresh `MockParameters`, including a `localVue`, `vuetify`, and `vuex` instance, the latter copying the basic `core` store structure, i.e., having an empty namespaced `plugin` module. 
 This is mostly done to avoid boilerplate code. For regularly used test contents, feel free to extend the returned contents.

--- a/packages/plugins/AddressSearch/README.md
+++ b/packages/plugins/AddressSearch/README.md
@@ -22,32 +22,32 @@ It is advised to either use one-search-per-group _or_ all services in a singular
 
 In `categoryProperties` and `groupProperties`, id strings called `groupId` and `categoryId` are used. These are arbitrary strings you can introduce and reuse to group or categorize elements together. Regarding what groups and categories are, see further below.
 
-| fieldName           | type                                  | description                                                                                                                                                                                                                                                            |
+| fieldName | type | description |
 | ------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| searchMethods       | searchMethodsObject[]                 | Array of search method descriptions. Only searches configured here can be used.                                                                                                                                                                                        |
+| searchMethods | searchMethodsObject[] | Array of search method descriptions. Only searches configured here can be used. |
 | afterResultComponent | VueConstructor? | If given, this component will be rendered in the last line of every single search result. It will be forwarded its search result feature as prop `feature` of type `GeoJSON.Feature`, and the focus state of the result as prop `focus` of type `boolean`. |
 | addLoading | string? | Optional loading action name to start loading. |
-| categoryProperties  | Record<string, categoryProperties>?   | An object defining properties for a category. The searchMethod's categoryId is used as identifier. A service without categoryId does not have a fallback category.                                                                                                     |
-| customSearchMethods | Record<string, customSearchMethod>?   | An object with named search functions added to the existing set of configurable search methods. (See `addressSearch.searchMethodsObject.type`) This record's keys are added to that enum.                                                                              |
-| customSelectResult  | Record<string, customSelectFunction>? | An object that maps categoryIds to functions. These functions are then called as vuex store actions instead of the `selectResult` default implementation. This allows overriding selection behaviour with full store access. Use `''` as key for categoryless results. |
+| categoryProperties | Record<string, categoryProperties>? | An object defining properties for a category. The searchMethod's categoryId is used as identifier. A service without categoryId does not have a fallback category. |
+| customSearchMethods | Record<string, customSearchMethod>? | An object with named search functions added to the existing set of configurable search methods. (See `addressSearch.searchMethodsObject.type`) This record's keys are added to that enum. |
+| customSelectResult | Record<string, customSelectFunction>? | An object that maps categoryIds to functions. These functions are then called as vuex store actions instead of the `selectResult` default implementation. This allows overriding selection behaviour with full store access. Use `''` as key for categoryless results. |
 | focusAfterSearch | boolean? | Whether the focus should switch to the first result after a successful search. Defaults to `false`. |
-| groupProperties     | Record<string, groupProperties>?      | An object defining properties for a group. The searchMethod's groupId is used as identifier. All services without groupId fall back to the key `"defaultGroup"`.                                                                                                       |
-| minLength           | number?                                | Minimal input length after which searches are started. Defaults to 0.                                                                                                                                                                                                                 |
+| groupProperties | Record<string, groupProperties>? | An object defining properties for a group. The searchMethod's groupId is used as identifier. All services without groupId fall back to the key `"defaultGroup"`. |
+| minLength | number? | Minimal input length after which searches are started. Defaults to 0. |
 | removeLoading | string? | Optional loading action name to end loading. |
-| waitMs              | number?                                | Debounce time in ms for search requests after last user input. Defaults to 0.                                                                                                                                                                                                         |
+| waitMs | number? | Debounce time in ms for search requests after last user input. Defaults to 0. |
 
 #### addressSearch.searchMethodsObject
 
-| fieldName       | type                                     | description                                                                                                                                                                                                                |
+| fieldName | type | description |
 | --------------- | ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| type            | enum["bkg", "gazetteer", "wfs", "mpapi"] | Service type. Enum can be extended by configuration, see `addressSearch.customSearchMethods`. ⚠️ "gazetteer" is deprecated. Please use "mpapi" instead. |
-| url             | string                                   | Search service URL. Should you require a service provider, please contact us for further information.                                                                                                                      |
-| categoryId      | string?                                  | Grouped services can optionally be distinguished in the UI with categories. See `addressSearch.categoryProperties` for configuration options.                                                                              |
-| groupId         | string?                                  | Default groupId is `"defaultGroup"`. All services with the same id are grouped and used together. See `addressSearch.groupProperties` for configuration options. If multiple groups exist, the UI offers a group switcher. |
-| hint            | string?                                  | Hint that is displayed below the input field if no other plugin-state-based hint is to be displayed. Can be a locale key. If grouped with other services, the group's hint will be used instead.                           |
-| label           | string?                                  | Display label. Can be a locale key. If grouped with other services, the group's label will be used instead.                                                                                                                |
-| placeholder     | string?                                  | Placeholder string to display on input element. Can be a locale key. If grouped with other services, the group's placeholder will be used instead.                                                                         |
-| queryParameters | object?                                   | The object further describes details for the search request. Its contents vary by service type, see documentation below.                                                                                                   |
+| type | enum["bkg", "gazetteer", "wfs", "mpapi"] | Service type. Enum can be extended by configuration, see `addressSearch.customSearchMethods`. ⚠️ "gazetteer" is deprecated. Please use "mpapi" instead. |
+| url | string | Search service URL. Should you require a service provider, please contact us for further information. |
+| categoryId | string? | Grouped services can optionally be distinguished in the UI with categories. See `addressSearch.categoryProperties` for configuration options. |
+| groupId | string? | Default groupId is `"defaultGroup"`. All services with the same id are grouped and used together. See `addressSearch.groupProperties` for configuration options. If multiple groups exist, the UI offers a group switcher. |
+| hint | string? | Hint that is displayed below the input field if no other plugin-state-based hint is to be displayed. Can be a locale key. If grouped with other services, the group's hint will be used instead. |
+| label | string? | Display label. Can be a locale key. If grouped with other services, the group's label will be used instead. |
+| placeholder | string? | Placeholder string to display on input element. Can be a locale key. If grouped with other services, the group's placeholder will be used instead. |
+| queryParameters | object? | The object further describes details for the search request. Its contents vary by service type, see documentation below. |
 
 #### addressSearch.customSearchMethod
 
@@ -87,38 +87,38 @@ With this, arbitrary click results can be supported. Please mind that undocument
 
 #### addressSearch.groupProperties
 
-| fieldName         | type                         | description                                                                                                                                                                                        |
+| fieldName | type | description |
 | ----------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| label             | string                       | Display label. Can be a locale key.                                                                                                                                                                |
+| label | string | Display label. Can be a locale key. |
 | resultDisplayMode | enum['mixed', 'categorized'] | Defaults to `'mixed'`. In `'mixed'`, results of all requested services are offered in a list in no specific order. In `'categorized'`, the results are listed by their searchService's categoryId. |
-| hint              | string?                      | Hint that is displayed below the input field if no other plugin-state-based hint is to be displayed. Can be a locale key.                                                                          |
-| limitResults      | number?                      | If set, only the first `n` results (per category in `categorized`) are displayed initially. All further results can be opened via UI.                                                              |
-| placeholder       | string?                      | Placeholder string to display on input element. Can be a locale key.                                                                                                                               |
+| hint | string? | Hint that is displayed below the input field if no other plugin-state-based hint is to be displayed. Can be a locale key. |
+| limitResults | number? | If set, only the first `n` results (per category in `categorized`) are displayed initially. All further results can be opened via UI. |
+| placeholder | string? | Placeholder string to display on input element. Can be a locale key. |
 
 #### addressSearch.categoryProperties
 
-| fieldName | type   | description                                                                                                                                                                                                              |
+| fieldName | type | description |
 | --------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| label     | string | Category label to display next to results to identify the source. Can be a locale key. Only relevant if the search's `groupProperties` linked via `groupId` contain a `resultDisplayMode` scenario that uses categories. |
+| label | string | Category label to display next to results to identify the source. Can be a locale key. Only relevant if the search's `groupProperties` linked via `groupId` contain a `resultDisplayMode` scenario that uses categories. |
 
 ##### addressSearch.searchMethodsObject.queryParameters (type:common)
 
 These fields are interpreted by all implemented services.
 
-| fieldName   | type   | description                             |
+| fieldName | type | description |
 | ----------- | ------ | --------------------------------------- |
 | maxFeatures | number? | Maximum amount of features to retrieve. Doesn't limit results if not set. |
 
 ##### addressSearch.searchMethodsObject.queryParameters (type:wfs)
 
-| fieldName     | type                   | description                                                                                                                                                                                                                                                                                                                                             |
+| fieldName | type | description |
 | ------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| featurePrefix | string                 | XML feature prefix for WFS service.                                                                                                                                                                                                                                                                                                                     |
-| typeName      | string                 | Feature type to search for by name.                                                                                                                                                                                                                                                                                                                     |
-| xmlns         | string                 | XML namespace to use in search.                                                                                                                                                                                                                                                                                                                         |
+| featurePrefix | string | XML feature prefix for WFS service. |
+| typeName | string | Feature type to search for by name. |
+| xmlns | string | XML namespace to use in search. |
 | fieldName | string? | Name of the type's field to search in. Mutually exclusive to `patterns`. |
-| patterns      | string[]?               | Allows specifying input patterns. In a single-field search, a pattern can be as easy as `{{theWholeThing}}`, where `theWholeThing` is also the feature field name to search in. In more complex scenarios, you may add separators and multiple fields, e.g. `{{gemarkung}} {{flur}} {{flstnrzae}}/{{flstnrnen}}` would fit many parcel search services. Mutually exclusive to `fieldName`. |
-| patternKeys   | Record<string, string>? | Maps field names from patterns to regexes. Each field name has to have a definition. Each regex must have one capture group that is used to search. Contents next to it are ignored for the search and just used for matching. E.g. `'([0-9]+)$'` would be a value for a key that fits an arbitrary number string at the input's end.                   |
+| patterns | string[]? | Allows specifying input patterns. In a single-field search, a pattern can be as easy as `{{theWholeThing}}`, where `theWholeThing` is also the feature field name to search in. In more complex scenarios, you may add separators and multiple fields, e.g. `{{gemarkung}} {{flur}} {{flstnrzae}}/{{flstnrnen}}` would fit many parcel search services. Mutually exclusive to `fieldName`. |
+| patternKeys | Record<string, string>? | Maps field names from patterns to regexes. Each field name has to have a definition. Each regex must have one capture group that is used to search. Contents next to it are ignored for the search and just used for matching. E.g. `'([0-9]+)$'` would be a value for a key that fits an arbitrary number string at the input's end. |
 | srsName | string? | Name of the projection (srs) for the query. |
 | useRightHandWildcard? | boolean? | By default, if searching for "search", it is sent as "search*". This behaviour can be deactivated by setting this parameter to `false`. |
 
@@ -128,27 +128,27 @@ Since inputs may overlap with multiple patterns, multiple queries are fired and 
 
 > ⚠️ "gazetteer" is deprecated. Please use "mpapi" instead.
 
-| fieldName     | type     | description                                                                                                   |
+| fieldName | type | description |
 | ------------- | -------- | ------------------------------------------------------------------------------------------------------------- |
 | epsg | `EPSG:${string}` | EPSG code of the projection to use. |
-| fieldName     | string[] | Field names of service to search in.                                                                          |
-| memberSuffix  | string   | Elements to interpret are fetched from response XML as `wfs:memberSuffix`; fitting suffix must be configured. |
-| namespaces    | string \| string[] | Namespaces to add to the request.                                                                             |
-| storedQueryId | string   | Name of the WFS-G stored query that is to be used.                                                            |
+| fieldName | string[] | Field names of service to search in. |
+| memberSuffix | string | Elements to interpret are fetched from response XML as `wfs:memberSuffix`; fitting suffix must be configured. |
+| namespaces | string \| string[] | Namespaces to add to the request. |
+| storedQueryId | string | Name of the WFS-G stored query that is to be used. |
 | version | '1.1.0' \| '2.0.0'? | WFS version used. Defaults to `'2.0.0'`. |
 
 ##### addressSearch.searchMethodsObject.queryParameters (type:mpapi)
 
 > **Please mind that this requires a configured backend. A WFS's Stored Query is requested with predefined parameters using the [masterportalApi](https://bitbucket.org/geowerkstatt-hamburg/masterportalapi/src/master/). This implementation is meant for e.g. https://geodienste.hamburg.de/HH_WFS_GAGES, but works with other WFS configured in the same manner.**
 
-| fieldName          | Type     | Description                                                                                                                                                                                                                 |
+| fieldName | Type | Description |
 | ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| searchAddress      | Boolean? | Defines whether address search is active. For backward compatibility, if "searchAddress" is not configured, the "searchAddress" attribute is set to "true" when "searchStreets" and "searchHouseNumbers" are set to "true". |
-| searchDistricts    | Boolean? | Defines whether district search is active.                                                                                                                                                                                  |
-| searchHouseNumbers | Boolean? | Defines whether house numbers should be searched for. Requires `searchStreets` to be set to `true`, too.                                                                                                                    |
-| searchParcels      | Boolean? | Defines whether parcels search is active.                                                                                                                                                                                   |
-| searchStreetKey    | Boolean? | Defines whether streets should be searched for by key.                                                                                                                                                                      |
-| searchStreets      | Boolean? | Defines whether street search is active. Precondition to set `searchHouseNumbers` to `true`.                                                                                                                                |
+| searchAddress | Boolean? | Defines whether address search is active. For backward compatibility, if "searchAddress" is not configured, the "searchAddress" attribute is set to "true" when "searchStreets" and "searchHouseNumbers" are set to "true". |
+| searchDistricts | Boolean? | Defines whether district search is active. |
+| searchHouseNumbers | Boolean? | Defines whether house numbers should be searched for. Requires `searchStreets` to be set to `true`, too. |
+| searchParcels | Boolean? | Defines whether parcels search is active. |
+| searchStreetKey | Boolean? | Defines whether streets should be searched for by key. |
+| searchStreets | Boolean? | Defines whether street search is active. Precondition to set `searchHouseNumbers` to `true`. |
 
 While all fields are optional, configuring none of them will yield undefined behaviour. At least one search instruction should be set to `true`.
 
@@ -158,7 +158,7 @@ In _BKG_ mode, queryParameter's key-value pairs are used in the service query. E
 
 For more options, please check the [official documentation](https://sg.geodatenzentrum.de/web_public/gdz/dokumentation/deu/geokodierungsdienst.pdf) regarding what query parameters are interpreted.
 
-Additionally, it is possible to configure the parameters `accesstoken` (`Authorization`) or `apiKey` (custom header `X-Api-Key`) to send the described headers to the search service for authentication purposes.  
+Additionally, it is possible to configure the parameters `accesstoken` (`Authorization`) or `apiKey` (custom header `X-Api-Key`) to send the described headers to the search service for authentication purposes. 
 Note that this changes the request to be non-simple. To be able to use the parameters, the request has to be sent in [`cors` mode](https://developer.mozilla.org/en-US/docs/Web/API/Request/mode) and has to support preflight request `OPTIONS`.
 
 ## Store
@@ -193,9 +193,9 @@ map.$store.dispatch('plugin/addressSearch/search', {
 
 The payload object supports the following fields:
 
-| fieldName  | type                           | description                                                                                                                                                                                                                                       |
+| fieldName | type | description |
 | ---------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| input      | string                         | Search string to be used.                                                                                                                                                                                                                         |
+| input | string | Search string to be used. |
 | autoselect | enum['first', 'only', 'never'] | By default, 'never' is selected, and results will be presented as if the user searched for them. Setting 'only' will autoselect if a single result was returned; setting 'first' will autoselect the first of an arbitrary amount of results >=1. |
 
 ### State

--- a/packages/plugins/Attributions/README.md
+++ b/packages/plugins/Attributions/README.md
@@ -10,18 +10,18 @@ This plugin shows attributions (that is, legal information) regarding copyrights
 
 All parameters are optional. However, setting neither `layerAttributions` nor `staticAttributions` results in an empty window.
 
-| fieldName          | type                         | description                                                                                                                                           |
+| fieldName | type | description |
 | ------------------ | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| initiallyOpen      | boolean?                     | Whether the information box is open by default. Only usable when renderType is set to 'independent', otherwise the IconMenu handles this.             |
-| layerAttributions  | layerAttribution[]?          | List of attributions that are shown when the matching layer is visible.                                                                               |
-| listenToChanges    | string[]?                    | Store variable paths to listen to for changes. Will update the currently visible layers depending on the current map state on changes to these values. Please mind that, when referencing another plugin, that plugin must be in `addPlugins` before this one. |
-| renderType         | 'iconMenu' \| 'independent'? | Whether this plugin ('independent') or the IconMenu should handle opening the information box. Defaults to 'independent'.                             |
-| staticAttributions | string[]?                    | List of static attributions that are always shown.                                                                                                    |
-| windowWidth        | number?                      | If `renderType` is set to `independent`, sets the width of the container of the attributions. Defaults to 500.                                                                                 |
+| initiallyOpen | boolean? | Whether the information box is open by default. Only usable when renderType is set to 'independent', otherwise the IconMenu handles this. |
+| layerAttributions | layerAttribution[]? | List of attributions that are shown when the matching layer is visible. |
+| listenToChanges | string[]? | Store variable paths to listen to for changes. Will update the currently visible layers depending on the current map state on changes to these values. Please mind that, when referencing another plugin, that plugin must be in `addPlugins` before this one. |
+| renderType | 'iconMenu' \| 'independent'? | Whether this plugin ('independent') or the IconMenu should handle opening the information box. Defaults to 'independent'. |
+| staticAttributions | string[]? | List of static attributions that are always shown. |
+| windowWidth | number? | If `renderType` is set to `independent`, sets the width of the container of the attributions. Defaults to 500. |
 
 #### attributions.layerAttribution
 
-| fieldName | type   | description                                                                                                                                           |
+| fieldName | type | description |
 | --------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| id        | string | ID of service the attribution relates to. The text will only be shown when the layer is visible.                                                      |
-| title     | string | Attribution text or localization key. May contain HTML. The tags `<YEAR>` and `<MONTH>` are translated to the current year or month respectively. |
+| id | string | ID of service the attribution relates to. The text will only be shown when the layer is visible. |
+| title | string | Attribution text or localization key. May contain HTML. The tags `<YEAR>` and `<MONTH>` are translated to the current year or month respectively. |

--- a/packages/plugins/Draw/README.md
+++ b/packages/plugins/Draw/README.md
@@ -31,25 +31,25 @@ The styling of the drawn features can be configured to overwrite the default ol-
 
 ### draw
 
-| fieldName           | type     | description                                                                  |
+| fieldName | type | description |
 | ------------------- | -------- | ---------------------------------------------------------------------------- |
 | selectableDrawModes | string[]? | List 'Point', 'LineString', 'Circle', 'Text' and/or 'Polygon' as desired. All besides 'Text' are selectable by default. |
-| style               | style? | Please see example below for styling options. Defaults to standard OpenLayers styling. |
-| textStyle           | object? | Use this object with properties 'font' and 'textColor' to style text feature. |
+| style | style? | Please see example below for styling options. Defaults to standard OpenLayers styling. |
+| textStyle | object? | Use this object with properties 'font' and 'textColor' to style text feature. |
 
 ##### draw.textStyle
 
-| fieldName | type             | description                                                                                                                     |
+| fieldName | type | description |
 | --------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| font      | object \| string | Style the font of the text feature with either css font properties or use font as an object with properties 'size' and 'family'. |
-| textColor | string?          | Define text color in hex or rgb / rgba code.                                                                                    |
+| font | object \| string | Style the font of the text feature with either css font properties or use font as an object with properties 'size' and 'family'. |
+| textColor | string? | Define text color in hex or rgb / rgba code. |
 
 ##### draw.textStyle.font
 
-| fieldName | type     | description                                                                         |
+| fieldName | type | description |
 | --------- | -------- | ----------------------------------------------------------------------------------- |
-| family    | string? | Font family.                                                                        |
-| size      | number[]? | Array with numbers that define the available text sizes that a user can choose from |
+| family | string? | Font family. |
+| size | number[]? | Array with numbers that define the available text sizes that a user can choose from |
 
 #### draw.style (by example)
 

--- a/packages/plugins/Export/README.md
+++ b/packages/plugins/Export/README.md
@@ -8,12 +8,12 @@ The Export plugin offers users to download the currently visible map canvas in a
 
 ### export
 
-| fieldName | type    | description                                                                                                                                                                           |
+| fieldName | type | description |
 | --------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| download  | boolean? | Whether file is offered for download. By default, no download will happen, and the using service is supposed to register whether a "screenshot" has been taken and react accordingly. |
-| showJpg   | boolean? | Tools offers current map view as JPG. Defaults to `true`. |
-| showPdf   | boolean? | Tools offers current map view as PDF. Defaults to `true`. |
-| showPng   | boolean? | Tools offers current map view as PNG. Defaults to `true`. |
+| download | boolean? | Whether file is offered for download. By default, no download will happen, and the using service is supposed to register whether a "screenshot" has been taken and react accordingly. |
+| showJpg | boolean? | Tools offers current map view as JPG. Defaults to `true`. |
+| showPdf | boolean? | Tools offers current map view as PDF. Defaults to `true`. |
+| showPng | boolean? | Tools offers current map view as PNG. Defaults to `true`. |
 
 ## Store
 

--- a/packages/plugins/Fullscreen/README.md
+++ b/packages/plugins/Fullscreen/README.md
@@ -8,9 +8,9 @@ The fullscreen plugin allows viewing the map in fullscreen mode. It relies solel
 
 ### fullscreen
 
-| fieldName         | type                         | description                                                                                                                                                         |
+| fieldName | type | description |
 |-------------------|------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| renderType        | 'iconMenu' \| 'independent'? | Whether the fullscreen button is being rendered independently or as part of the IconMenu. Defaults to 'independent'.                                                |
+| renderType | 'iconMenu' \| 'independent'? | Whether the fullscreen button is being rendered independently or as part of the IconMenu. Defaults to 'independent'. |
 | targetContainerId | string? | Specifies the html element on which the fullscreen mode should be applied. If the parameter is omitted, it falls back to the configured global field `containerId`. |
 
 ## Store

--- a/packages/plugins/GeoLocation/README.md
+++ b/packages/plugins/GeoLocation/README.md
@@ -10,16 +10,16 @@ either `true` or `false`. When a users denies the location tracking, the button 
 
 #### geoLocation
 
-| fieldName              | type    | description                                                                                                                                                                                                                                                                                         |
+| fieldName | type | description |
 | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| boundaryLayerId        | string? | Id of a vector layer to restrict geolocation markers and zooms to. When geolocation outside of its features occurs, an information will be shown once and the feature is stopped. The map will wait at most 10s for the layer to load; should it not happen, the geolocation feature is turned off. |
+| boundaryLayerId | string? | Id of a vector layer to restrict geolocation markers and zooms to. When geolocation outside of its features occurs, an information will be shown once and the feature is stopped. The map will wait at most 10s for the layer to load; should it not happen, the geolocation feature is turned off. |
 | boundaryOnError | ('strict' \| 'permissive')? | If the boundary layer check does not work due to loading or configuration errors, style `'strict'` will disable the geolocation feature, and style `'permissive'` will act as if no boundaryLayerId was set. Defaults to `'permissive'`. |
 | checkLocationInitially | boolean? | If `true` the location gets checked on page load. When `false` this can be triggered with a button. Defaults to `false`. |
-| keepCentered           | boolean? | If `true`, the map will re-center on the user on any position change. If `false`, only the first position will be centered on. Defaults to `false`. |
+| keepCentered | boolean? | If `true`, the map will re-center on the user on any position change. If `false`, only the first position will be centered on. Defaults to `false`. |
 | renderType | 'iconMenu' \| 'independent'? | If nested in `IconMenu`, select 'iconMenu' to match styling. Defaults to 'independent'. |
 | showTooltip | boolean? | If set to `true`, a tooltip will be shown when hovering the geoposition marker in the map, indicating that it shows the user's position. Defaults to `false`. |
 | toastAction | string? | If the user is not locatable within the boundary of the maps extent or the boundary of the layer of `boundaryLayerId`, this string will be used as action to send a toast information to the user. If no toast information is desired, leave this field undefined; for testing purposes, you can still find information in the console. |
-| zoomLevel              | number? | Specifies to which zoom level gets zoomed after a successfull tracking of the location. Defaults to `7`. |
+| zoomLevel | number? | Specifies to which zoom level gets zoomed after a successfull tracking of the location. Defaults to `7`. |
 
 #### Example configuration
 

--- a/packages/plugins/Gfi/README.md
+++ b/packages/plugins/Gfi/README.md
@@ -10,29 +10,29 @@ The GFI plugin can be used to fetch and optionally display GFI (GetFeatureInfo) 
 
 #### gfi
 
-| fieldName            | type                                                                                              | description                                                                                                                                                                                                                                                                                                                                                                               |
+| fieldName | type | description |
 | -------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| coordinateSources    | string[]                                                                                          | The GFI plugin will react to these coordinate positions in the store. This allows it to react to e.g. the address search of the pins plugin. Please see example configuration for the common use-cases. Please mind that, when referencing another plugin, that plugin must be in `addPlugins` before this one. |
-| layers               | Record<string, gfiLayerConfiguration>                                                             | Maps a string (must be a layer ID) to a behaviour configuration for that layer.                                                                                                                                                                                                                                                                                                           |
+| coordinateSources | string[] | The GFI plugin will react to these coordinate positions in the store. This allows it to react to e.g. the address search of the pins plugin. Please see example configuration for the common use-cases. Please mind that, when referencing another plugin, that plugin must be in `addPlugins` before this one. |
+| layers | Record<string, gfiLayerConfiguration> | Maps a string (must be a layer ID) to a behaviour configuration for that layer. |
 | activeLayerPath | string? | Optional store path to array of active mask layer ids. If used with `LayerChooser`, setting this to `'plugin/layerChooser/activeMaskIds'` will result in an info text in the GFI box, should no layer be active. If used without `LayerChooser`, the active mask layers have to be provided by another plugin or the client. If not set, the GFI plugin may e.g. show an empty list, which may be confusing to some users. |
-| afterLoadFunction    | function (featuresByLayerId: Record<string, GeoJsonFeature[]>): Record<layerId, GeoJsonFeature[]>? | This method can be used to extend, filter, or otherwise modify a GFI result.                                                                                                                                                                                                                                                                                                              |
-| customHighlightStyle | customHighlighStyle? | If required a user can change the stroke and fill of the highlighted feature. The default style as seen in the example will be used for each part that is not customized. An empty object will return the complete default style while e.g. for an object without a configured fill the default fill will be applied.                                                                     |
+| afterLoadFunction | function (featuresByLayerId: Record<string, GeoJsonFeature[]>): Record<layerId, GeoJsonFeature[]>? | This method can be used to extend, filter, or otherwise modify a GFI result. |
+| customHighlightStyle | customHighlighStyle? | If required a user can change the stroke and fill of the highlighted feature. The default style as seen in the example will be used for each part that is not customized. An empty object will return the complete default style while e.g. for an object without a configured fill the default fill will be applied. |
 | featureList | featureList? | If defined, a list of available vector layer features is visible when no feature is selected. Only usable if `renderType` is set to `iconMenu` and `window` is set to `true` for at least one configured layer. |
-| gfiContentComponent  | Vue?                                                                                              | Allows overriding the GfiContent.vue component for a custom design. Coding knowledge required to use this feature.                                                                                                                                                                                                                                                                        |
+| gfiContentComponent | Vue? | Allows overriding the GfiContent.vue component for a custom design. Coding knowledge required to use this feature. |
 | maxFeatures | number? | Limits the viewable GFIs per layer by this number. The first n elements are chosen arbitrarily. Useful if you e.g. just want one result, or to limit an endless stream of returns to e.g. 10. Infinite by default. |
-| mode                 | enum["bboxDot", "intersects"]? | Method of calculating which feature has been chosen by the user. `bboxDot` utilizes the `bbox`-url parameter using the clicked coordinate while `intersects` uses a `Filter` to calculate the intersected features. Layers can have their own `gfiMode` parameter which would override this global mode. To apply this, add the desired value to the parameter in the `mapConfiguration`. Defaults to `'bboxDot'`. |
+| mode | enum["bboxDot", "intersects"]? | Method of calculating which feature has been chosen by the user. `bboxDot` utilizes the `bbox`-url parameter using the clicked coordinate while `intersects` uses a `Filter` to calculate the intersected features. Layers can have their own `gfiMode` parameter which would override this global mode. To apply this, add the desired value to the parameter in the `mapConfiguration`. Defaults to `'bboxDot'`. |
 | renderType | ('iconMenu' \| 'independent')? | Only relevant if `window` is set to `true` for at least one layer. Whether the gfi plugin is rendered independently or as part of the IconMenu. Defaults to 'independent'. |
 
 ##### gfi.gfiLayerConfiguration
 
-| fieldName      | type                                       | description                                                                                                                                                                                                                                          |
+| fieldName | type | description |
 | -------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| exportProperty | string? | Property of the features of a service having an url usable to trigger a download of features as a document.                                                                                                                                          |
-| geometry       | boolean? | If true, feature geometry will be highlighted within the map. Defaults to `false`. |
-| geometryName   | string? | Name of the geometry property if not the default field. |
-| properties     | Record<propertyName, displayName>/string[] | In case `window` is `true`, this will be used to determine which contents to show. In case of an array, keys are used to select properties. In case of an object, keys are used to select properties, but will be titles as their respective values. Displays all properties by default. |
+| exportProperty | string? | Property of the features of a service having an url usable to trigger a download of features as a document. |
+| geometry | boolean? | If true, feature geometry will be highlighted within the map. Defaults to `false`. |
+| geometryName | string? | Name of the geometry property if not the default field. |
+| properties | Record<propertyName, displayName>/string[] | In case `window` is `true`, this will be used to determine which contents to show. In case of an array, keys are used to select properties. In case of an object, keys are used to select properties, but will be titles as their respective values. Displays all properties by default. |
 | showTooltip | ((feature: Feature) => [string, string][])? | If given, a tooltip will be shown with the values calculated for the feature. The first string is the HTML tag to render, the second its contents; contants may be locale keys. For more information regarding the strings, see the documentation of the `@polar/lib-tooltip` package. Defaults to `undefined`. Please mind that tooltips will only be shown if a mouse is used or the hovering device could not be detected. Touch and pen interactions do not open tooltips since they will open the GFI window, rendering the gatherable information redundant. |
-| window         | boolean? | If true, properties will be shown in the map client. Defaults to `false`. |
+| window | boolean? | If true, properties will be shown in the map client. Defaults to `false`. |
 
 Additionally, if using a WMS service, the following properties can be configured as well.
 
@@ -43,10 +43,10 @@ Additionally, if using a WMS service, the following properties can be configured
 
 ##### gfi.customHighlightStyle
 
-| fieldName | type   | description                          |
+| fieldName | type | description |
 | --------- | ------ | ------------------------------------ |
-| fill      | ol/style/Fill? | Object for defining the fill style. See [OpenLayers documentation](https://openlayers.org/en/latest/apidoc/module-ol_style_Fill-Fill.html) for full options. |
-| stroke    | ol/style/Stroke? | Object for defining the stroke style.  See [OpenLayers documentation](https://openlayers.org/en/latest/apidoc/module-ol_style_Stroke-Stroke.html) for full options. |
+| fill | ol/style/Fill? | Object for defining the fill style. See [OpenLayers documentation](https://openlayers.org/en/latest/apidoc/module-ol_style_Fill-Fill.html) for full options. |
+| stroke | ol/style/Stroke? | Object for defining the stroke style. See [OpenLayers documentation](https://openlayers.org/en/latest/apidoc/module-ol_style_Stroke-Stroke.html) for full options. |
 
 ##### gfi.featureList
 

--- a/packages/plugins/LayerChooser/README.md
+++ b/packages/plugins/LayerChooser/README.md
@@ -14,31 +14,31 @@ The tool does not require any configuration for itself, but is based on the `map
 
 Each object in `mapConfiguration.layers` array fits this definition:
 
-| fieldName  | type                       | description                                                                            |
+| fieldName | type | description |
 | ---------- | -------------------------- | -------------------------------------------------------------------------------------- |
-| id         | string                     | Service register id.                                                                   |
-| name       | string                     | Display name in UI.                                                                    |
-| type       | enum["background", "mask"] | Layer handling. Backgrounds are mutually exclusive, masks ("overlays") can be stacked. |
+| id | string | Service register id. |
+| name | string | Display name in UI. |
+| type | enum["background", "mask"] | Layer handling. Backgrounds are mutually exclusive, masks ("overlays") can be stacked. |
 | hideInMenu | boolean? | Can be set for layers of type `'mask'` to hide them in the selection menu. |
-| maxZoom    | number?                    | If set, layer only available (and selectable) to this zoom level.                      |
-| minZoom    | number?                    | If set, layer only available (and selectable) from this zoom level on.                 |
-| options    | options?                   | Shows a layer-specific sub-menu; its contents are configurable.                        |
-| visibility | boolean?                   | Initial visibility. Defaults to `false`. |
+| maxZoom | number? | If set, layer only available (and selectable) to this zoom level. |
+| minZoom | number? | If set, layer only available (and selectable) from this zoom level on. |
+| options | options? | Shows a layer-specific sub-menu; its contents are configurable. |
+| visibility | boolean? | Initial visibility. Defaults to `false`. |
 
 ### mapConfiguration.layers.options
 
 An option wheel will appear in the layer chooser that allows opening a sub-menu with configured configuration options for the end user.
 
-| fieldName | type              | description                                                                                                                                                                                                 |
+| fieldName | type | description |
 | --------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| layers    | options.layers | If configured, all configured _layers of the layer_ can be turned off and on by the user. ⚠️ Only implemented for WMS. Only implemented for top layers; that is, only first level of nesting is considered. |
+| layers | options.layers | If configured, all configured _layers of the layer_ can be turned off and on by the user. ⚠️ Only implemented for WMS. Only implemented for top layers; that is, only first level of nesting is considered. |
 
 #### mapConfiguration.layers.options.layers
 
 This field is named like this to match the OGC specification for their name; that is, layers have layers that may have layers that may have layers, and so on. However, only the first level (a layer's layers) is currently implemented.
 
-| fieldName | type                               | description                                                                                                                                                                                                                                                                                                                                             |
+| fieldName | type | description |
 | --------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| legend    | boolean \| Record<name, legendUrl>? | Legend image to be used for sub-layer. If false, no image is displayed. If true, it is assumed an image exists in the layer's GetCapabilities, and that will be used. If Record, it maps the layer name to a linked image. The `legendUrl` can be any valid reachable image URL.                                                                        |
-| order     | string?                            | Optional. If not given, field `layers` from service description will be used, and defines order of options. If layer defined in service description's `layers` and `order`, it's initially on. If only in `order`, it's initially off. If only in `layers`, it's always-on. If in neither, it's always-off.                                             |
-| title     | boolean \| Record<name, layerName>? | Title to be displayed for sub-layer. If false, layer name itself will be used as given in service description 'layers' field. If true, it is assumed a name exists in the layer's GetCapabilities, and that will be used. If Record, it maps the layer name to an arbitrary display name given by the configuration. The `layerName` can be any string. |
+| legend | boolean \| Record<name, legendUrl>? | Legend image to be used for sub-layer. If false, no image is displayed. If true, it is assumed an image exists in the layer's GetCapabilities, and that will be used. If Record, it maps the layer name to a linked image. The `legendUrl` can be any valid reachable image URL. |
+| order | string? | Optional. If not given, field `layers` from service description will be used, and defines order of options. If layer defined in service description's `layers` and `order`, it's initially on. If only in `order`, it's initially off. If only in `layers`, it's always-on. If in neither, it's always-off. |
+| title | boolean \| Record<name, layerName>? | Title to be displayed for sub-layer. If false, layer name itself will be used as given in service description 'layers' field. If true, it is assumed a name exists in the layer's GetCapabilities, and that will be used. If Record, it maps the layer name to an arbitrary display name given by the configuration. The `layerName` can be any string. |

--- a/packages/plugins/LoadingIndicator/README.md
+++ b/packages/plugins/LoadingIndicator/README.md
@@ -25,7 +25,7 @@ As such, **always call `removeLoadingKey` in the `finally` section of your code*
 
 You may desire to listen to whether the loader is currently being shown.
 
-| fieldName  | type    | description                           |
+| fieldName | type | description |
 | ---------- | ------- | ------------------------------------- |
 | showLoader | boolean | Whether the layer is currently shown. |
 

--- a/packages/plugins/Pins/README.md
+++ b/packages/plugins/Pins/README.md
@@ -10,39 +10,39 @@ The usage of `displayComponent` has no influence on the creation of Pins on the 
 
 ### pins
 
-| fieldName        | type          | description                                                                                                                                                                                                                                                                                         |
+| fieldName | type | description |
 | ---------------- | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| appearOnClick    | appearOnClick?? | Pin restrictions. See object description below.                                                                                                                                                                                                                                                     |
-| boundaryLayerId  | string?       | Id of a vector layer to restrict pins to. When pins are moved or created outside of the boundary, an information will be shown and the pin is reset to its previous state. The map will wait at most 10s for the layer to load; should it not happen, the geolocation feature is turned off.        |
+| appearOnClick | appearOnClick?? | Pin restrictions. See object description below. |
+| boundaryLayerId | string? | Id of a vector layer to restrict pins to. When pins are moved or created outside of the boundary, an information will be shown and the pin is reset to its previous state. The map will wait at most 10s for the layer to load; should it not happen, the geolocation feature is turned off. |
 | boundaryOnError | ('strict' \| 'permissive')? | If the boundary layer check does not work due to loading or configuration errors, style `'strict'` will disable the pins feature, and style `'permissive'` will act as if no boundaryLayerId was set. Defaults to `'permissive'`. |
 | coordinateSource | string? | The pins plugin may react to changes in other plugins. This specifies the path to such store positions. The position must, when subscribed to, return a GeoJSON feature. Please mind that, when referencing another plugin, that plugin must be in `addPlugins` before this one. |
-| initial          | initial? | Configuration options for setting an initial pin. |
-| movable          | boolean? \| 'drag' \| 'click' \| 'none' | Whether a user may drag and re-click the pin (`drag` or `true`), only re-click it (`click`) or may only be placed programmatically (`none` or `false`). Defaults to 'none'. **Using a boolean for this configuration has been deprecated and will be removed in the next major release.**           |
-| style            | style?        | Display style configuration.                                                                                                                                                                                                                                                                        |
-| toastAction      | string?       | If `boundaryLayerId` is set, and the pin is moved or created outside the boundary, this string will be used as action to send a toast information to the user. If no toast information is desired, leave this field undefined; for testing purposes, you can still find information in the console. |
-| toZoomLevel      | number? | Zoom level to use on outside input by e.g. address search. Defaults to `0`. |
+| initial | initial? | Configuration options for setting an initial pin. |
+| movable | boolean? \| 'drag' \| 'click' \| 'none' | Whether a user may drag and re-click the pin (`drag` or `true`), only re-click it (`click`) or may only be placed programmatically (`none` or `false`). Defaults to 'none'. **Using a boolean for this configuration has been deprecated and will be removed in the next major release.** |
+| style | style? | Display style configuration. |
+| toastAction | string? | If `boundaryLayerId` is set, and the pin is moved or created outside the boundary, this string will be used as action to send a toast information to the user. If no toast information is desired, leave this field undefined; for testing purposes, you can still find information in the console. |
+| toZoomLevel | number? | Zoom level to use on outside input by e.g. address search. Defaults to `0`. |
 
 #### pins.appearOnClick
 
-| fieldName   | type    | description                              |
+| fieldName | type | description |
 |-------------|---------|------------------------------------------|
-| show        | boolean | Display marker.                          |
+| show | boolean | Display marker. |
 | atZoomLevel | number? | Minimum zoom level for sensible marking. Defaults to `0`. |
 
 #### pins.initial
 
-| fieldName   | type     | description                                                                                                                           |
+| fieldName | type | description |
 |-------------|----------|---------------------------------------------------------------------------------------------------------------------------------------|
-| coordinates | number[] | Coordinate pair for the pin.                                                                                                          |
-| centerOn    | boolean? | If set to true, center on and zoom to the given coordinates on start. Defaults to false.                                              |
-| epsg        | string?  | Coordinate reference system in which the given coordinates are encoded. Defaults to the `epsg` value defined in the mapConfiguration. |
+| coordinates | number[] | Coordinate pair for the pin. |
+| centerOn | boolean? | If set to true, center on and zoom to the given coordinates on start. Defaults to false. |
+| epsg | string? | Coordinate reference system in which the given coordinates are encoded. Defaults to the `epsg` value defined in the mapConfiguration. |
 
 #### pins.style
 
-| fieldName | type    | description                                                               |
+| fieldName | type | description |
 | --------- | ------- | ------------------------------------------------------------------------- |
-| fill      | string? | Fill color of the pin. Defaults to blue (`#005CA9`).                      |
-| stroke    | string? | Stroke (that is, border) color of the pin. Defaults to white (`#FFFFFF`). |
+| fill | string? | Fill color of the pin. Defaults to blue (`#005CA9`). |
+| stroke | string? | Stroke (that is, border) color of the pin. Defaults to white (`#FFFFFF`). |
 
 ## Store
 

--- a/packages/plugins/ReverseGeocoder/README.md
+++ b/packages/plugins/ReverseGeocoder/README.md
@@ -10,14 +10,14 @@ This module has been written for the HH WPS service. The return format is custom
 
 ### reverseGeocoder
 
-| fieldName        | type    | description                                                                                                                                                                                        |
+| fieldName | type | description |
 | ---------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| url              | string  | URL of the WPS to use for reverse geocoding.                                                                                                                                                       |
-| addLoading       | string? | Points to an action in the store; commited with a loading key as payload on starting reverse geocoding.                                                                                            |
-| addressTarget    | string? | Points to a path in the store where an address can be put. If given, ReverseGeocoder will update on resolve. If not given, ReverseGeocoder's results can only be retrieved by awaiting its action. |
+| url | string | URL of the WPS to use for reverse geocoding. |
+| addLoading | string? | Points to an action in the store; commited with a loading key as payload on starting reverse geocoding. |
+| addressTarget | string? | Points to a path in the store where an address can be put. If given, ReverseGeocoder will update on resolve. If not given, ReverseGeocoder's results can only be retrieved by awaiting its action. |
 | coordinateSource | string? | Points to a path in the store where a coordinate may be. If given, ReverseGeocoder will resolve on any updates. If not given, ReverseGeocoder is passive and waits for its action to be called. Please mind that, when referencing another plugin, that plugin must be in `addPlugins` before this one. |
-| removeLoading    | string? | Points to an action in the store; commited with a loading key as payload on finishing reverse geocoding.                                                                                           |
-| zoomTo           | number? | If specified, plugin zooms to given coordinate after successful reverse geocoding; number indicates maximal zoom level.                                                                            |
+| removeLoading | string? | Points to an action in the store; commited with a loading key as payload on finishing reverse geocoding. |
+| zoomTo | number? | If specified, plugin zooms to given coordinate after successful reverse geocoding; number indicates maximal zoom level. |
 
 ## Store
 

--- a/packages/plugins/Toast/README.md
+++ b/packages/plugins/Toast/README.md
@@ -10,19 +10,19 @@ Please check the vuetify documentation to override the success, warning, info, o
 
 ### toast
 
-| fieldName | type       | description                           |
+| fieldName | type | description |
 | --------- | ---------- | ------------------------------------- |
-| error     | toastStyle? | Design override for error messages.   |
-| info      | toastStyle? | Design override for info messages.    |
-| success   | toastStyle? | Design override for success messages. |
-| warning   | toastStyle? | Design override for warning messages. |
+| error | toastStyle? | Design override for error messages. |
+| info | toastStyle? | Design override for info messages. |
+| success | toastStyle? | Design override for success messages. |
+| warning | toastStyle? | Design override for warning messages. |
 
 #### toast.toastStyle
 
-| fieldName | type    | description                                                                                                          |
+| fieldName | type | description |
 | --------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| color     | string? | Either a color code like '#FACADE' or a color string [vuetify understands](https://vuetifyjs.com/en/styles/colors/). |
-| icon      | string? | CSS icon class.                                                                                                      |
+| color | string? | Either a color code like '#FACADE' or a color string [vuetify understands](https://vuetifyjs.com/en/styles/colors/). |
+| icon | string? | CSS icon class. |
 
 ## Store
 
@@ -36,13 +36,13 @@ map.$store.dispatch('plugin/toast/addToast', payload)
 
 #### Payload structure
 
-| fieldName | type                                        | description                                                                                    |
+| fieldName | type | description |
 | --------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------- |
-| type      | enum['error', 'warning', 'info', 'success'] | Decides the default toast colouring and icon.                                                  |
-| text      | string                                      | Textual user information. This may either be a user-readable string or a translation key.      |
-| timeout   | number                                      | Any positive non-null number will be used as ms until the toast is closed. 0 means no timeout. |
-| color     | ?string                                     | See {toast.toastStyle}. Overrides setting for this toast only.                                 |
-| icon      | ?string                                     | See {toast.toastStyle}. Overrides setting for this toast only.                                 |
+| type | enum['error', 'warning', 'info', 'success'] | Decides the default toast colouring and icon. |
+| text | string | Textual user information. This may either be a user-readable string or a translation key. |
+| timeout | number | Any positive non-null number will be used as ms until the toast is closed. 0 means no timeout. |
+| color | ?string | See {toast.toastStyle}. Overrides setting for this toast only. |
+| icon | ?string | See {toast.toastStyle}. Overrides setting for this toast only. |
 
 #### Usage example
 

--- a/packages/plugins/Zoom/README.md
+++ b/packages/plugins/Zoom/README.md
@@ -6,13 +6,13 @@ The Zoom plugin offers functionality regarding map zooming.
 
 ## Configuration
 
-The Zoom plugin offers a plus/minus button, and will adjust itself to the map's zoom settings on initialization.  
+The Zoom plugin offers a plus/minus button, and will adjust itself to the map's zoom settings on initialization. 
 It can be configured as followed.
 
-| fieldName  | type                         | description                                                                                   |
+| fieldName | type | description |
 |------------|------------------------------|-----------------------------------------------------------------------------------------------|
 | renderType | 'iconMenu' \| 'independent'? | Whether the zoom related buttons are being rendered independently or as part of the IconMenu. Defaults to `'independent'`. |
-| showMobile | boolean?                     | Whether the zoom related buttons should be displayed on smaller devices; defaults to `false`.   |
+| showMobile | boolean? | Whether the zoom related buttons should be displayed on smaller devices; defaults to `false`. |
 
 ## Store
 
@@ -20,11 +20,11 @@ It can be configured as followed.
 
 The map's zoom level can be listened to.
 
-| fieldName              | type    | description                                   |
+| fieldName | type | description |
 | ---------------------- | ------- | --------------------------------------------- |
-| zoomLevel              | number  | Current OpenLayers zoom level.                |
-| maximumZoomLevel       | number  | Maximum OpenLayers zoom level.                |
-| minimumZoomLevel       | number  | Minimum OpenLayers zoom level.                |
+| zoomLevel | number | Current OpenLayers zoom level. |
+| maximumZoomLevel | number | Maximum OpenLayers zoom level. |
+| minimumZoomLevel | number | Minimum OpenLayers zoom level. |
 
 ```js
 map.subscribe('plugin/zoom/zoomLevel', (zoomLevel) => {


### PR DESCRIPTION
## Summary

Removal of whitespaces in tables within all ``Readme.md`` files.

## Instructions for local reproduction and review
Check the contents of the ``Readme.md`` files, it should only affect whitespaces within tables and some whitespaces at the end-of-line, but not Code Blocks.

## Relevant tickets, issues, et cetera
https://jira.dataport.de/browse/POLAR-326 