### PR TITLE
Feature/easing between zoom levels

### DIFF
--- a/packages/plugins/Zoom/CHANGELOG.md
+++ b/packages/plugins/Zoom/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unpublished
 
+- Feature: Add easing between zoom levels.
 - Refactor: Remove redundant prop `isHorizontal` from `Zoom` component. Logic is now placed in `@polar/core`.
 
 ## 1.2.0

--- a/packages/plugins/Zoom/src/store/index.ts
+++ b/packages/plugins/Zoom/src/store/index.ts
@@ -56,7 +56,7 @@ export const makeStoreModule = () => {
         if (view) {
           view.animate({
             zoom: zoomLevel,
-            duration: 1000,
+            duration: 500,
           })
         }
       },

--- a/packages/plugins/Zoom/src/store/index.ts
+++ b/packages/plugins/Zoom/src/store/index.ts
@@ -31,6 +31,7 @@ export const makeStoreModule = () => {
           getters: { maximumZoomLevel, minimumZoomLevel, zoomLevel },
           rootGetters: { map },
           commit,
+          dispatch,
         },
         payload
       ) {
@@ -41,7 +42,7 @@ export const makeStoreModule = () => {
           map
         ) {
           commit('setZoomLevel', payload)
-          map.getView().setZoom(payload)
+          dispatch('smoothZoom')
         }
       },
       increaseZoomLevel({ dispatch, getters: { zoomLevel } }): void {
@@ -49,6 +50,15 @@ export const makeStoreModule = () => {
       },
       decreaseZoomLevel({ dispatch, getters: { zoomLevel } }): void {
         dispatch('setZoomLevel', zoomLevel - 1)
+      },
+      smoothZoom({ rootGetters: { map }, getters: { zoomLevel } }): void {
+        const view = map.getView()
+        if (view) {
+          view.animate({
+            zoom: zoomLevel,
+            duration: 1000,
+          })
+        }
       },
     },
     mutations: {


### PR DESCRIPTION
## Summary

With the new changes, the zoom between zoom levels works smoother now. 

## Instructions for local reproduction and review

Start a client and zoom in and out via zoom buttons or mouse.

I assumed that the smooth zoom is preferred and should be standard, so I just replaced the old zoom with the new method.

I'm not sure if the duration of the animation should be configurable, I just used a value of 1000. Let me know if this is something that I should add.

