### PR TITLE
fix ts client check

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lint": "npx eslint . --cache --ext .js,.ts,.vue",
     "lint:ci": "npx eslint . --ext .js,.ts,.vue",
     "lint:fix": "npx eslint . --fix --cache --ext .js,.ts,.vue",
-    "tsc:ci": "tsc -P tsconfig.ci.json",
+    "tsc:ci": "tsc --noEmit",
     "postinstall": "lerna bootstrap --hoist",
     "publishPackages": "node ./scripts/publishPackages",
     "test": "jest",

--- a/packages/clients/dish/src/utils/search.ts
+++ b/packages/clients/dish/src/utils/search.ts
@@ -1,6 +1,7 @@
 import { FeatureCollection, GeoJsonProperties, Geometry } from 'geojson'
 import { getWfsFeatures } from '@polar/lib-get-features'
 import { rawLayerList } from '@masterportal/masterportalapi'
+import { CoreGetters, CoreState, PolarStore } from '@polar/lib-custom-types'
 import {
   WfsConfiguration,
   EfiSearchFeature,
@@ -132,6 +133,7 @@ const sortAndShort =
  * DISH "Denkmalsuche" search method (injectable for plugin/AddressSearch)
  */
 export function search(
+  this: PolarStore<CoreState, CoreGetters>,
   signal: AbortSignal,
   url: string,
   inputValue: string,

--- a/packages/clients/generic/src/polar-client.ts
+++ b/packages/clients/generic/src/polar-client.ts
@@ -85,7 +85,7 @@ const addPlugins = (coreInstance: PolarCore, enabledPlugins: PluginName[]) => {
           plugin: Gfi({
             renderType: 'iconMenu',
             coordinateSources: [],
-            layers: [],
+            layers: {},
           }),
           icon: 'fa-location-pin',
           id: 'gfi',
@@ -121,6 +121,7 @@ const addPlugins = (coreInstance: PolarCore, enabledPlugins: PluginName[]) => {
       enabledPlugins.includes('address-search') &&
         AddressSearch({
           layoutTag: NineLayoutTag.TOP_LEFT,
+          searchMethods: [],
         }),
       enabledPlugins.includes('pins') && Pins({}),
       enabledPlugins.includes('legend') &&
@@ -137,7 +138,10 @@ const addPlugins = (coreInstance: PolarCore, enabledPlugins: PluginName[]) => {
         LoadingIndicator({
           layoutTag: NineLayoutTag.MIDDLE_MIDDLE,
         }),
-      enabledPlugins.includes('reverse-geocoder') && ReverseGeocoder({}),
+      enabledPlugins.includes('reverse-geocoder') &&
+        ReverseGeocoder({
+          url: '',
+        }),
       enabledPlugins.includes('scale') &&
         Scale({
           layoutTag: NineLayoutTag.BOTTOM_RIGHT,

--- a/packages/clients/meldemichel/src/addPlugins.ts
+++ b/packages/clients/meldemichel/src/addPlugins.ts
@@ -31,6 +31,7 @@ export const addPlugins = (core, mode: keyof typeof MODE) => {
         layoutTag: NineLayoutTag.TOP_LEFT,
         addLoading: 'plugin/loadingIndicator/addLoadingKey',
         removeLoading: 'plugin/loadingIndicator/removeLoadingKey',
+        searchMethods: [],
       }),
       Pins({
         appearOnClick: { show: true, atZoomLevel: 0 },

--- a/packages/clients/meldemichel/src/store/module.ts
+++ b/packages/clients/meldemichel/src/store/module.ts
@@ -1,11 +1,7 @@
 // some names are defined by the environment
 /* eslint-disable camelcase */
 
-import {
-  AddressSearchConfiguration,
-  PolarModule,
-} from '@polar/lib-custom-types'
-import { AddressSearchState } from '@polar/plugin-address-search'
+import { PolarModule } from '@polar/lib-custom-types'
 
 interface SetMapStatePayload {
   mapCenter?: string // resembling 'number,number'

--- a/packages/clients/meldemichel/src/store/module.ts
+++ b/packages/clients/meldemichel/src/store/module.ts
@@ -1,7 +1,11 @@
 // some names are defined by the environment
 /* eslint-disable camelcase */
 
-import { PolarModule } from '@polar/lib-custom-types'
+import {
+  AddressSearchConfiguration,
+  PolarModule,
+} from '@polar/lib-custom-types'
+import { AddressSearchState } from '@polar/plugin-address-search'
 
 interface SetMapStatePayload {
   mapCenter?: string // resembling 'number,number'

--- a/packages/clients/meldemichel/src/utils/createMenus.ts
+++ b/packages/clients/meldemichel/src/utils/createMenus.ts
@@ -15,12 +15,15 @@ export default function (mode: keyof typeof MODE): Menu[] {
       id: 'layerChooser',
     },
     mode === MODE.COMPLETE && {
-      plugin: Filter({}),
+      plugin: Filter({
+        layers: {},
+      }),
       icon: 'fa-filter',
       id: 'filter',
     },
     mode === MODE.COMPLETE && {
       plugin: Gfi({
+        layers: {},
         gfiContentComponent: MeldemichelGfiFeature,
         renderType: 'iconMenu',
         coordinateSources: [

--- a/packages/types/custom/core.ts
+++ b/packages/types/custom/core.ts
@@ -107,9 +107,10 @@ export interface AddressSearchConfiguration extends PluginOptions {
   categoryProperties?: Record<string, AddressSearchCategoryProperties>
   // optional additional search methods (client-side injections)
   customSearchMethods?: Record<string, SearchMethodFunction>
-  /** NOTE regarding \<unknown, unknown\> – skipping further type chain upwards precision due to object optionality/clutter that would continue to MapConfig level; the inverted rabbit hole ends here */
+  /** NOTE regarding \<any, any\> – skipping further type chain upwards precision due to object optionality/clutter that would continue to MapConfig level; the inverted rabbit hole ends here; not using "unknown" since that errors in client configuration, not using "never" since that errors in AddressSearch plugin; this way, "any"thing goes */
   // optional selectResult overrides (client-side injections)
-  customSelectResult?: Record<string, SelectResultFunction<unknown, unknown>>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  customSelectResult?: Record<string, SelectResultFunction<any, any>>
   focusAfterSearch?: boolean
   // definition of groups referred to in searchMethods
   groupProperties?: Record<string, AddressSearchGroupProperties>
@@ -649,7 +650,9 @@ export interface CoreState {
   mapHasDimensions: boolean
   moveHandle: number
   moveHandleActionButton: number
-  plugin: object
+  // NOTE truly any since external plugins may bring whatever; unknown will lead to further errors
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  plugin: Record<string, any>
   selected: number
   zoomLevel: number
 }

--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": true
-  }
-}

--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -1,6 +1,5 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["packages/clients"],
   "compilerOptions": {
     "noEmit": true
   }


### PR DESCRIPTION
## Summary

*looks at ts client check setup*

I can fix it.

## Instructions for local reproduction and review

Pipeline should now run through and tsc also checks clients. I've fixed the setup in that I added (mostly unnecessarily) default configuration properties (that will still throw errors in the plugins if not overridden, so no harm done here) and adjusted some types. I've also entertained `any` to resolve some of the problems, where both `unknown` and `never` would result in errors in varying positions. While not quite ideal, this is imo sufficient by the 20-80 rule.

The biggest gain here is that we've now enabled type checking for clients so that we can stop preventable issues from sneaking in.