### PR TITLE
refactor method (linting, readability)

### DIFF
--- a/packages/plugins/Export/src/store/actions.ts
+++ b/packages/plugins/Export/src/store/actions.ts
@@ -1,6 +1,91 @@
 import { jsPDF } from 'jspdf'
 import { PolarActionTree } from '@polar/lib-custom-types'
+import { Map } from 'ol'
 import { ExportFormat, ExportGetters, ExportState } from '../types'
+
+// PDF options
+const dims = {
+  a0: [1189, 841],
+  a1: [841, 594],
+  a2: [594, 420],
+  a3: [420, 297],
+  a4: [297, 210],
+  a5: [210, 148],
+}
+
+// Screenshot canvas
+const CANVAS_ID = 'export-canvas'
+
+const convertToPdf = (map: Map, src: string, size: number[]) => {
+  // NOTE: when supporting more formats, scale map accordingly
+  const format = 'a4'
+  const dim = dims[format]
+  // Import of jspdf is in mounted.
+  const jsPdf = new jsPDF('landscape', undefined, format) // eslint-disable-line
+  jsPdf.addImage(src, 'JPEG', 0, 0, dim[0], dim[1])
+  // Reset original map size
+  map.setSize(size)
+  map.getView().setResolution(map.getView().getResolution())
+
+  return {
+    pdfSrc: jsPdf.output('datauristring'),
+    jsPdf,
+  }
+}
+
+const downloadAsImage = (src: string, type: ExportFormat) => {
+  const link = document.createElement('a')
+  link.download = 'map.' + (type === ExportFormat.PNG ? 'png' : 'jpeg')
+  link.href = src
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}
+
+// For every ol-layer, get matrix and apply on canvas
+const getDataUrl = (size: number[], type: ExportFormat) => {
+  // The canvas to render the screenshot in
+  const mapCanvas: HTMLCanvasElement = document.createElement('canvas')
+  mapCanvas.id = CANVAS_ID
+  // mapCanvas.setAttribute('crossOrigin', 'anonymous')
+  mapCanvas.width = size[0]
+  mapCanvas.height = size[1]
+
+  // Write on this
+  const mapContext = mapCanvas.getContext('2d')
+  if (!mapContext) {
+    console.error(
+      '@polar/plugin-export: map does not of a 2d context, export failed.'
+    )
+    return
+  }
+
+  Array.prototype.forEach.call(
+    document.querySelector('[data-app]')?.querySelectorAll('.ol-layer canvas'),
+    function (canvas) {
+      if (canvas.width > 0) {
+        const opacity = canvas.parentNode.style.opacity
+        mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity)
+        const transform = canvas.style.transform
+        // Get the transform parameters from the style's transform matrix
+        const matrix = transform
+          .match(/^matrix\(([^(]*)\)$/)[1]
+          .split(',')
+          .map(Number)
+        // Apply the transform to the export map context
+        CanvasRenderingContext2D.prototype.setTransform.apply(
+          mapContext,
+          matrix
+        )
+        mapContext.drawImage(canvas, 0, 0)
+      } else console.warn('@polar/plugin-export: canvas width is 0')
+    }
+  )
+
+  return mapCanvas.toDataURL(
+    type === ExportFormat.PNG ? 'image/png' : 'image/jpeg'
+  )
+}
 
 const actions: PolarActionTree<ExportState, ExportGetters> = {
   exportAs(
@@ -12,98 +97,23 @@ const actions: PolarActionTree<ExportState, ExportGetters> = {
       return
     }
 
-    // PDF options
-    const dims = {
-      a0: [1189, 841],
-      a1: [841, 594],
-      a2: [594, 420],
-      a3: [420, 297],
-      a4: [297, 210],
-      a5: [210, 148],
-    }
-
-    //  Screenshot canvas
-    const CANVAS_ID = 'export-canvas'
-
-    map.getInteractions().forEach((interaction) => {
-      interaction.setActive(false)
-    })
+    map.getInteractions().forEach((interaction) => interaction.setActive(false))
 
     map.once('postrender', function () {
-      // Map properties
       const size = map.getSize()
       if (!Array.isArray(size) || size.length !== 2) {
         throw Error('Export: Map has no size.')
       }
-      const viewResolution = map.getView().getResolution()
-      // The canvas to render the screenshot in
-      const mapCanvas: HTMLCanvasElement = document.createElement('canvas')
-      mapCanvas.id = CANVAS_ID
-      // mapCanvas.setAttribute('crossOrigin', 'anonymous')
-      mapCanvas.width = size[0]
-      mapCanvas.height = size[1]
-
-      // Write on this
-      const mapContext = mapCanvas.getContext('2d')
-      if (!mapContext) {
-        console.error(
-          '@polar/plugin-export: map does not of a 2d context, export failed.'
-        )
-        return
-      }
-      // For every ol-layer, get matrix and apply on canvas
-      Array.prototype.forEach.call(
-        document
-          .querySelector('[data-app]')
-          ?.querySelectorAll('.ol-layer canvas'),
-        function (canvas) {
-          if (canvas.width > 0) {
-            const opacity = canvas.parentNode.style.opacity
-            mapContext.globalAlpha = opacity === '' ? 1 : Number(opacity)
-            const transform = canvas.style.transform
-            // Get the transform parameters from the style's transform matrix
-            const matrix = transform
-              .match(/^matrix\(([^(]*)\)$/)[1]
-              .split(',')
-              .map(Number)
-            // Apply the transform to the export map context
-            CanvasRenderingContext2D.prototype.setTransform.apply(
-              mapContext,
-              matrix
-            )
-            mapContext.drawImage(canvas, 0, 0)
-          } else console.warn('@polar/plugin-export: canvas width is 0')
-        }
-      )
-
-      let src = mapCanvas.toDataURL(
-        type === ExportFormat.PNG ? 'image/png' : 'image/jpeg'
-      )
+      let src = getDataUrl(size, type)
+      if (!src) return
 
       if (type === ExportFormat.JPG || type === ExportFormat.PNG) {
-        if (download) {
-          const link = document.createElement('a')
-          link.download = 'map.' + (type === ExportFormat.PNG ? 'png' : 'jpeg')
-          link.href = src
-          document.body.appendChild(link)
-          link.click()
-          document.body.removeChild(link)
-        }
+        if (download) downloadAsImage(src, type)
       } else {
-        // TODO: decide on a format, scale map accordingly
-        const format = 'a4'
-        const dim = dims[format]
-        // Import of jspdf is in mounted.
-        const pdf = new jsPDF('landscape', undefined, format) // eslint-disable-line
-        pdf.addImage(src, 'JPEG', 0, 0, dim[0], dim[1])
-        // Reset original map size
-        map.setSize(size)
-        map.getView().setResolution(viewResolution)
-        src = pdf.output('datauristring')
+        const { pdfSrc, jsPdf } = convertToPdf(map, src, size)
+        src = pdfSrc
 
-        if (download) {
-          pdf.save('map.pdf')
-        }
+        if (download) jsPdf.save('map.pdf')
       }
 
       map.getInteractions().forEach((interaction) => {
@@ -112,6 +122,7 @@ const actions: PolarActionTree<ExportState, ExportGetters> = {
 
       commit('setExportedMap', src)
     })
+
     map.renderSync()
   },
 }


### PR DESCRIPTION
## Summary

Improve readability of export implementation. Remove linting warning.

## Instructions for local reproduction and review

Fiddle with export tool in snowbox to check some combinations. Snippet as reminder:

```json
{
  export: {
    showPng: true,
    showJpg: true,
    showPdf: true,
    download: true,
  }
}
```

## Relevant tickets, issues, et cetera

#33 