### PR TITLE
Additionally expose createMap for @polar/client-generic

### DIFF
--- a/packages/clients/generic/CHANGELOG.md
+++ b/packages/clients/generic/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Directly expose `createMap` to be able to import it directly when using this client.
+
 ## 1.0.0
 
 Initial release.

--- a/packages/clients/generic/src/polar-client.ts
+++ b/packages/clients/generic/src/polar-client.ts
@@ -156,38 +156,40 @@ const addPlugins = (coreInstance: PolarCore, enabledPlugins: PluginName[]) => {
   )
 }
 
+export const createMap = ({
+  containerId,
+  services,
+  mapConfiguration,
+  enabledPlugins = [],
+  modifyLayerConfiguration = (x) => x,
+}: {
+  containerId: string
+  services: object[]
+  mapConfiguration: MapConfig
+  enabledPlugins: Array<PluginName>
+  modifyLayerConfiguration: (layerConf: object[]) => object[]
+}) =>
+  new Promise((resolve) => {
+    const coreInstance = { ...core }
+
+    addPlugins(coreInstance, enabledPlugins)
+
+    coreInstance.rawLayerList.initializeLayerList(
+      services,
+      async (layerConf) => {
+        const client = await coreInstance.createMap({
+          containerId,
+          mapConfiguration: {
+            ...mapConfiguration,
+            layerConf: modifyLayerConfiguration(layerConf),
+          },
+        })
+
+        resolve(client)
+      }
+    )
+  })
+
 export default {
-  createMap: ({
-    containerId,
-    services,
-    mapConfiguration,
-    enabledPlugins = [],
-    modifyLayerConfiguration = (x) => x,
-  }: {
-    containerId: string
-    services: object[]
-    mapConfiguration: MapConfig
-    enabledPlugins: Array<PluginName>
-    modifyLayerConfiguration: (layerConf: object[]) => object[]
-  }) =>
-    new Promise((resolve) => {
-      const coreInstance = { ...core }
-
-      addPlugins(coreInstance, enabledPlugins)
-
-      coreInstance.rawLayerList.initializeLayerList(
-        services,
-        async (layerConf) => {
-          const client = await coreInstance.createMap({
-            containerId,
-            mapConfiguration: {
-              ...mapConfiguration,
-              layerConf: modifyLayerConfiguration(layerConf),
-            },
-          })
-
-          resolve(client)
-        }
-      )
-    }),
+  createMap,
 }

--- a/pages/examples/render.js
+++ b/pages/examples/render.js
@@ -1,4 +1,4 @@
-import client from '../node_modules/@polar/client-generic/dist/polar-client.js'
+import { createMap } from '../node_modules/@polar/client-generic/dist/polar-client.js'
 
 const commonParameters = {
   services: 'https://geodienste.hamburg.de/services-internet.json',
@@ -25,7 +25,7 @@ ${(typeof description === 'string' ? [description] : description)
   <summary>View configuration</summary>
   <pre>
     <code>
-client.createMap(${JSON.stringify(parameterObject, null, 2)})
+      createMap(${JSON.stringify(parameterObject, null, 2)})
     </code>
   </pre>
 </details>
@@ -81,7 +81,7 @@ export default ({
 
   document.getElementById('render-node').appendChild(card)
 
-  client.createMap(parameterObject).then((mapClient) => {
+  createMap(parameterObject).then((mapClient) => {
     if (postCreation) {
       postCreation({ mapClient, id })
     }


### PR DESCRIPTION
## Summary

As the title says, `@polar/client-generic` now additionally exposes `createMap` to be able to use it directly.

## Instructions for local reproduction and review

`npm run pages:build && npm run pages:build:serve`. This should then also work in the pipeline.