### PR TITLE
Adjust overlay mechanic for macOS devices

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Feature: Add `deviceIsHorizontal` as a getter to have a more central place to check if the device is in landscape mode.
 - Fix: Adjust documentation to properly describe optionality of configuration parameters.
 - Fix: Add package `events` as a dependency to fix issue with `xml2js`. See https://github.com/Leonidas-from-XIV/node-xml2js/issues/697 for more information.
+- Fix: Adjust overlay to properly be displayed on macOS devices.
 - Chore: Update dependencies to latest versions.
 
 ## 1.4.1

--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -6,7 +6,7 @@
         class="polar-map-overlay"
       >
         <template v-if="noControlOnZoom">
-          {{ $t('common:overlay.noControlOnZoom') }}
+          {{ $t(overlayLocale) }}
         </template>
         <template v-else-if="oneFingerPan">
           {{ $t('common:overlay.oneFingerPan') }}
@@ -91,6 +91,14 @@ export default Vue.extend({
       'moveHandle',
       'moveHandleActionButton',
     ]),
+    isMacOS() {
+      return navigator.userAgent.indexOf('Mac') !== -1
+    },
+    overlayLocale() {
+      return `common:overlay.${
+        this.isMacOS ? 'noCommandOnZoom' : 'noControlOnZoom'
+      }`
+    },
     renderMoveHandle() {
       return (
         this.moveHandle !== null && this.hasWindowSize && this.hasSmallWidth
@@ -203,9 +211,9 @@ export default Vue.extend({
         }
       }
     },
-    wheelEffect({ ctrlKey }) {
+    wheelEffect(event: WheelEvent) {
       clearTimeout(this.noControlOnZoomTimeout)
-      this.noControlOnZoom = !ctrlKey
+      this.noControlOnZoom = this.isMacOS ? !event.metaKey : !event.ctrlKey
       this.noControlOnZoomTimeout = setTimeout(
         () => (this.noControlOnZoom = false),
         2000

--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -58,6 +58,8 @@ import MapUi from './MapUi.vue'
 // NOTE: OpenLayers styles need to be imported as the map resides in the shadow DOM
 import 'ol/ol.css'
 
+const isMacOS = navigator.userAgent.indexOf('Mac') !== -1
+
 export default Vue.extend({
   components: {
     MapUi,
@@ -91,13 +93,8 @@ export default Vue.extend({
       'moveHandle',
       'moveHandleActionButton',
     ]),
-    isMacOS() {
-      return navigator.userAgent.indexOf('Mac') !== -1
-    },
     overlayLocale() {
-      return `common:overlay.${
-        this.isMacOS ? 'noCommandOnZoom' : 'noControlOnZoom'
-      }`
+      return `common:overlay.${isMacOS ? 'noCommandOnZoom' : 'noControlOnZoom'}`
     },
     renderMoveHandle() {
       return (
@@ -213,7 +210,7 @@ export default Vue.extend({
     },
     wheelEffect(event: WheelEvent) {
       clearTimeout(this.noControlOnZoomTimeout)
-      this.noControlOnZoom = this.isMacOS ? !event.metaKey : !event.ctrlKey
+      this.noControlOnZoom = isMacOS ? !event.metaKey : !event.ctrlKey
       this.noControlOnZoomTimeout = setTimeout(
         () => (this.noControlOnZoom = false),
         2000

--- a/packages/core/src/language/locales/de.ts
+++ b/packages/core/src/language/locales/de.ts
@@ -11,6 +11,8 @@ const de: Resource = {
     },
     overlay: {
       noControlOnZoom: 'Verwenden Sie Strg+Scrollen zum Zoomen der Karte',
+      noCommandOnZoom:
+        'Verwenden Sie Command ⌘ + Scrollen zum Zoomen der Karte',
       oneFingerPan:
         'Verwenden Sie mindestens zwei Finger zum Verschieben der Karte',
     },

--- a/packages/core/src/language/locales/en.ts
+++ b/packages/core/src/language/locales/en.ts
@@ -11,6 +11,7 @@ const en: Resource = {
     },
     overlay: {
       noControlOnZoom: 'Use Ctrl+Mousewheel to zoom into the map',
+      noCommandOnZoom: 'Use Command ⌘ + Mousewheel to zoom into the map',
       oneFingerPan: 'Use at least two fingers to pan the map',
     },
   },


### PR DESCRIPTION
## Summary

On macOS, the Command-Key is being used instead of Ctrl as a modifier for zooming.
This change now fixes that, so the Overlay is now being displayed on macOS devices.

## Instructions for local reproduction and review

Run e.g. `snowbox` and take a look, if it still works as intended for Windows devices.
