### PR TITLE
add configuration error warning

### DIFF
--- a/packages/core/src/vuePlugins/vuex.ts
+++ b/packages/core/src/vuePlugins/vuex.ts
@@ -241,6 +241,12 @@ export const makeStore = () => {
         }
         if (state.configuration[name].displayComponent) {
           commit('setComponents', [...components, component])
+
+          if (!state.configuration[name].layoutTag) {
+            console.warn(
+              `Component "${name}" was registered as visible ('displayComponent' had a truthy value), but no layout tag was associated. This may be an error in configuration and will lead to the component not being visible in the UI.`
+            )
+          }
         }
       },
       centerOnFeature({ rootGetters: { map } }, feature: Feature) {

--- a/packages/core/src/vuePlugins/vuex.ts
+++ b/packages/core/src/vuePlugins/vuex.ts
@@ -244,7 +244,7 @@ export const makeStore = () => {
 
           if (!state.configuration[name].layoutTag) {
             console.warn(
-              `Component "${name}" was registered as visible ('displayComponent' had a truthy value), but no layout tag was associated. This may be an error in configuration and will lead to the component not being visible in the UI.`
+              `@polar/core: Component "${name}" was registered as visible ('displayComponent' had a truthy value), but no 'layoutTag' was associated. This may be an error in configuration and will lead to the component not being visible in the UI.`
             )
           }
         }


### PR DESCRIPTION
## Summary

The client now warns upon finding components that are indicated to be visible by the `displayComponent` flag, but lack a `layoutTag`.

## Instructions for local reproduction and review

You may intentionally break any configuration by removing the layout tag to see the warning.