### PR TITLE
Fix/geojson

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -333,7 +333,7 @@ Whitelisted and confirmed parameters include:
 - WMS:  id, name, url, typ, format, version, transparent, layers, STYLES
 - WFS:  id, name, url, typ, outputFormat, version, featureType
 - WMTS: id, name, urls, typ, capabilitiesUrl, optionsFromCapabilities, tileMatrixSet, layers, legendURL, format, coordinateSystem, origin, transparent, tileSize, minScale, maxScale, requestEncoding, resLength
-- GeoJSON: id, name, url, typ, format, version, minScale, maxScale, legendURL
+- GeoJSON: id, name, url, typ, version, minScale, maxScale, legendURL, gfiAttributes?
 
 ###### Example services register
 
@@ -392,7 +392,6 @@ Whitelisted and confirmed parameters include:
     "name": "My GeoJSON data",
     "url": "Service url",
     "typ": "GeoJSON",
-    "format": "XML",
     "version": "1.0",
     "minScale": "0",
     "maxScale": "2500000",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -333,7 +333,7 @@ Whitelisted and confirmed parameters include:
 - WMS:  id, name, url, typ, format, version, transparent, layers, STYLES
 - WFS:  id, name, url, typ, outputFormat, version, featureType
 - WMTS: id, name, urls, typ, capabilitiesUrl, optionsFromCapabilities, tileMatrixSet, layers, legendURL, format, coordinateSystem, origin, transparent, tileSize, minScale, maxScale, requestEncoding, resLength
-- GeoJSON: id, name, url, typ, version, minScale, maxScale, legendURL, gfiAttributes?
+- GeoJSON: id, name, url, typ, version, minScale, maxScale, legendURL
 
 ###### Example services register
 

--- a/packages/plugins/Gfi/CHANGELOG.md
+++ b/packages/plugins/Gfi/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix: Adjust documentation to properly describe optionality of configuration parameters.
 - Fix: Add missing configuration parameters `featureList` and `maxFeatures` to the general documentation and `filterBy` and `format` to `gfi.gfiLayerConfiguration`
 - Fix: Add missing entry of `gfiContentComponent` to `GfiGetters`.
+- Fix: Fix issue rendering properties of a feature if a value is not a string.
 - Refactor: Replace redundant prop-forwarding with `getters`.
 - Refactor: Use core getter `clientWidth` instead of local computed value.
 - Chore: expand on the description to `gfiContentComponent` in the Readme.md.

--- a/packages/plugins/Gfi/src/components/FeatureTableBody.vue
+++ b/packages/plugins/Gfi/src/components/FeatureTableBody.vue
@@ -2,7 +2,12 @@
   <tbody>
     <tr v-for="[key, value] of Object.entries(filteredProperties)" :key="key">
       <td>{{ key }}</td>
-      <td v-if="value.match(/\.(jpeg|jpg|gif|png)$/) !== null">
+      <td
+        v-if="
+          typeof value === 'string' &&
+          value.match(/\.(jpeg|jpg|gif|png)$/) !== null
+        "
+      >
         <a :href="value" target="_blank">
           <img
             :src="value"

--- a/packages/plugins/Gfi/src/utils/requestGfiGeoJson.ts
+++ b/packages/plugins/Gfi/src/utils/requestGfiGeoJson.ts
@@ -28,7 +28,7 @@ export default ({
   layer: VectorLayer<Feature>
 }): Promise<GeoJsonFeature[]> =>
   Promise.resolve(
-    coordinateOrExtent.length === 2
+    (coordinateOrExtent.length === 2
       ? map.getFeaturesAtPixel(map.getPixelFromCoordinate(coordinateOrExtent), {
           layerFilter: (candidate) => candidate === layer,
         })
@@ -38,11 +38,12 @@ export default ({
           .getFeaturesInExtent(coordinateOrExtent)
           .map(getNestedFeatures)
           .flat(1)
-          .map((feature) =>
-            feature instanceof Feature
-              ? JSON.parse(writer.writeFeature(feature))
-              : false
-          )
-          // remove FeatureLikes
-          .filter((x) => x)
+    )
+      .map((feature) =>
+        feature instanceof Feature
+          ? JSON.parse(writer.writeFeature(feature))
+          : false
+      )
+      // remove FeatureLikes
+      .filter((x) => x)
   )


### PR DESCRIPTION
## Summary

When testing some GeoJSON I've realized some issues with my previous implementation which are being fixed here.
- `format` is not needed on GeoJSON
- Fix an issue if a value of a property is not a string
- Fix implementation for GeoJSON gfi requests using a coordinate

## Instructions for local reproduction and review

Meldemichel and snowbox should be tested
