### PR TITLE
Fix/assign cross origin param for image wms

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Set crossOrigin for ImageWMS to `anonymous` to prevent error in canvas rendering (e.g. when using export plugin).
+
 ## 2.0.0
 
 - Breaking: Upgrade `@masterportal/masterportalapi` from `2.8.0` to `2.40.0` and subsequently `ol` from `^7.1.0` to `^9.2.4`.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unpublished
 
-- Fix: Set crossOrigin for ImageWMS to `anonymous` to prevent error in canvas rendering (e.g. when using export plugin).
+- Fix: Add `crossOrigin` differently to layer sources that are an instance of `ImageWMS` as they require it being set as `crossOrigin_` to be recognized.
 
 ## 2.0.0
 

--- a/packages/core/src/monkeyCrossOrigin.ts
+++ b/packages/core/src/monkeyCrossOrigin.ts
@@ -1,4 +1,5 @@
 import { Map } from 'ol'
+import { ImageWMS } from 'ol/source'
 
 // Original addLayer method
 const originalAddLayer = Map.prototype.addLayer
@@ -13,7 +14,9 @@ Map.prototype.addLayer = function (...parameters) {
     .forEach((layer) => {
       // @ts-expect-error | All layers here are instantiated layers including a source.
       const source = layer.getSource()
-      source.crossOrigin = 'anonymous'
+      // set private param for ol class ImageWMS to prevent error in canvas rendering | Undocumented.
+      if (source instanceof ImageWMS) source.crossOrigin_ = 'anonymous'
+      else source.crossOrigin = 'anonymous'
       // @ts-expect-error | All layers here are instantiated layers including a source.
       layer.setSource(source)
     })

--- a/packages/core/src/monkeyCrossOrigin.ts
+++ b/packages/core/src/monkeyCrossOrigin.ts
@@ -14,7 +14,8 @@ Map.prototype.addLayer = function (...parameters) {
     .forEach((layer) => {
       // @ts-expect-error | All layers here are instantiated layers including a source.
       const source = layer.getSource()
-      // set private param for ol class ImageWMS to prevent error in canvas rendering | Undocumented.
+      // @ts-expect-error | Set private param for ol class ImageWMS to prevent error in canvas rendering.
+      // Might break after ol upgrade because its undocumented.
       if (source instanceof ImageWMS) source.crossOrigin_ = 'anonymous'
       else source.crossOrigin = 'anonymous'
       // @ts-expect-error | All layers here are instantiated layers including a source.


### PR DESCRIPTION
## Summary

The private parameter `crossOrigin` of the ol class ImageWMS is now set to `anonymous` to prevent errors in canvas rendering.

When configuring a WMS with `singleTile: true` the WMS is loaded as an ImageWMS. This ol class has the private parameter crossOrigin which has not been effected by the previous method to set this parameter. If a WMS is configured like described, the Export Plugin which uses canvas rendering throws an error. 

## Instructions for local reproduction and review

- To recreate this error, start a client which uses the Export plugin and a WMS that is configured with the parameter `singleTile: true`.
- Click the export Button.
- The export does not work. See browser console for error.

## Relevant tickets, issues, et cetera

#204 
