### PR TITLE
Fix/scale switcher tooltip

### DIFF
--- a/packages/clients/dish/CHANGELOG.md
+++ b/packages/clients/dish/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Fix: Extend typing for search result function according to type package update.
 - Fix: Import types `AddressSearchState` and `AddressSearchGetters` from correct position.
 - Fix: Import enum `SearchResultSymbols` from correct position.
-- Fix: Add translations for scale switcher.
 - Chore: Change value of `pins.movable` configuration to `'drag'` as using a boolean has been deprecated in a future release.
 - Chore: Upgrade `@masterportal/masterportalapi` from `2.8.0` to `2.40.0` and subsequently `ol` from `^7.1.0` to `^9.2.4`.
 - Chore: Update `@polar`-dependencies to the latest versions.

--- a/packages/clients/dish/CHANGELOG.md
+++ b/packages/clients/dish/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix: Extend typing for search result function according to type package update.
 - Fix: Import types `AddressSearchState` and `AddressSearchGetters` from correct position.
 - Fix: Import enum `SearchResultSymbols` from correct position.
+- Fix: Add translations for scale switcher.
 - Chore: Change value of `pins.movable` configuration to `'drag'` as using a boolean has been deprecated in a future release.
 - Chore: Upgrade `@masterportal/masterportalapi` from `2.8.0` to `2.40.0` and subsequently `ol` from `^7.1.0` to `^9.2.4`.
 - Chore: Update `@polar`-dependencies to the latest versions.

--- a/packages/plugins/Scale/CHANGELOG.md
+++ b/packages/plugins/Scale/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Add missing translations for scale switcher.
+
 ## 2.0.0
 
 - Breaking: Upgrade peerDependency `ol` from `^7.1.0` to `^9.2.4`.

--- a/packages/plugins/Scale/src/language.ts
+++ b/packages/plugins/Scale/src/language.ts
@@ -8,6 +8,7 @@ const language: LanguageOption[] = [
         scale: {
           toOneNegative: 'Skalierung muss eine positive Zahl sein',
           label: 'Skala',
+          scaleSwitcher: 'Maßstab ändern',
         },
       },
     },
@@ -19,6 +20,7 @@ const language: LanguageOption[] = [
         scale: {
           toOneNegative: 'scale must be a positive number',
           label: 'Scale',
+          scaleSwitcher: 'Change scale',
         },
       },
     },


### PR DESCRIPTION
## Summary

The tooltip for scale switcher was showing only the translation key. So the missing translation for scale switcher was added.

## Instructions for local reproduction and review

Start a portal with a configured scale switcher, e.g. start the dish client after adding
```
scale: {
  showScaleSwitcher: true,
  zoomMethod: 'plugin/zoom/setZoomLevel',
}
```
to mapConfig.ts

Then hover with mouse over scale switcher and check if translation is shown.