### PR TITLE
fix tooltip font family

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unpublished
 
 - Fix: Add `crossOrigin` differently to layer sources that are an instance of `ImageWMS` as they require it being set as `crossOrigin_` to be recognized.
+- Fix: Add missing `font-family` css so that tooltips are always `Arial, sans-serif`.
 
 ## 2.0.0
 

--- a/packages/core/src/utils/createMap/pullVuetifyStyleToShadow.ts
+++ b/packages/core/src/utils/createMap/pullVuetifyStyleToShadow.ts
@@ -15,7 +15,7 @@ export const pullVuetifyStyleToShadow = (shadowRoot: ShadowRoot) => {
   // tooltips are technically a neighbour of the app; add missing font style
   const tooltipStyle = document.createElement('style')
   tooltipStyle.innerHTML = `.v-tooltip__content {
-  font-family: Arial, sans-serif;
+  font-family: sans-serif;
 }`
   shadowRoot.appendChild(tooltipStyle)
 }

--- a/packages/core/src/utils/createMap/pullVuetifyStyleToShadow.ts
+++ b/packages/core/src/utils/createMap/pullVuetifyStyleToShadow.ts
@@ -11,4 +11,11 @@ export const pullVuetifyStyleToShadow = (shadowRoot: ShadowRoot) => {
     return
   }
   shadowRoot.appendChild(vuetifyStyle)
+
+  // tooltips are technically a neighbour of the app; add missing font style
+  const tooltipStyle = document.createElement('style')
+  tooltipStyle.innerHTML = `.v-tooltip__content {
+  font-family: Arial, sans-serif;
+}`
+  shadowRoot.appendChild(tooltipStyle)
 }


### PR DESCRIPTION
## Summary

Since tooltips are technically a neighbour of the #app, the correct font styles missed the the target.

## Instructions for local reproduction and review

Check client tooltips. You can e.g. view the difference in DISH.
