### PR TITLE
Change order of layers to fix overlapping layers

### DIFF
--- a/packages/clients/snowbox/src/mapConfiguration.ts
+++ b/packages/clients/snowbox/src/mapConfiguration.ts
@@ -237,15 +237,15 @@ export const mapConfiguration = {
       name: 'snowbox.layers.rapid',
     },
     {
-      id: reports,
-      type: 'mask',
-      name: 'snowbox.layers.reports',
-    },
-    {
       id: ausgleichsflaechen,
       type: 'mask',
       name: 'snowbox.layers.ausgleichsflaechen',
       styleId: 'panda',
+    },
+    {
+      id: reports,
+      type: 'mask',
+      name: 'snowbox.layers.reports',
     },
     {
       id: hamburgBorder,


### PR DESCRIPTION
## Summary

Change order of layers so that the pins dont get overlapped by other layers.

## Instructions for local reproduction and review

`npm run snowbox`

## Pull Request Checklist (for Assignee)

*No functional changes*

- [ ] Changelogs are maintained
- [ ] Functionality has been tested in Firefox, Chrome, Safari
- [ ] Functionality has been tested on a smartphone
- [ ] Functionality has been tested with 200% screen zoom
- [ ] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [ ] Chrome Lighthouse
  - [ ] Firefox Accessibility

## Relevant tickets, issues, et cetera

None