### PR TITLE
Change mail to new shorter alias

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -27,12 +27,12 @@ jobs:
       - uses: EndBug/add-and-commit@v9
         with:
           author_name: Dataport Geo Bot
-          author_email: dataportpolarsupport@dataport.de
+          author_email: polar@dataport.de
       - run: |
           for TAG in ${{ env.TAGS }}
           do
             git config user.name "Dataport Geo Bot"
-            git config user.email "dataportpolarsupport@dataport.de"
+            git config user.email "polar@dataport.de"
             git tag $TAG
             git push origin $TAG
             echo "Released and tagged $TAG"

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-dataportpolarsupport@dataport.de.
+reported to the community leaders responsible for enforcement at polar@dataport.de.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-There is no formally defined process about contributions to the POLAR repository yet. For any contributions, please contact dataportpolarsupport@dataport.de with your matter in question.
+There is no formally defined process about contributions to the POLAR repository yet. For any contributions, please contact polar@dataport.de with your matter in question.
 
 ## Issues
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ For a detailed step-by-step guide, please refer to our comprehensive [Getting St
 
 ## Stay In Touch
 
-- [Contact us via email 📧](mailto:dataportpolarsupport@dataport.de)
+- [Contact us via email 📧](mailto:polar@dataport.de)
 
 made by [Dataport](https://www.dataport.de/) with ❤️

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "polar-monorepo",
   "private": true,
   "description": "monorepository to build masterportalAPI-based map clients",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "license": "EUPL-1.2",
   "engines": {
     "node": "^20.16.0",

--- a/packages/clients/afm/package.json
+++ b/packages/clients/afm/package.json
@@ -10,7 +10,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "dist/polar-client.js",
   "repository": {
     "type": "git",

--- a/packages/clients/diplan/package.json
+++ b/packages/clients/diplan/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "dist/polar-client.js",
   "repository": {
     "type": "git",

--- a/packages/clients/dish/package.json
+++ b/packages/clients/dish/package.json
@@ -5,7 +5,7 @@
   "keywords": ["OpenLayers", "ol", "POLAR", "client", "DISH", "monument", "memorial"],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Dataport/polar.git",

--- a/packages/clients/generic/package.json
+++ b/packages/clients/generic/package.json
@@ -5,7 +5,7 @@
   "keywords": ["OpenLayers", "ol", "POLAR", "client", "generic"],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "dist/polar-client.js",
   "repository": {
     "type": "git",

--- a/packages/clients/meldemichel/package.json
+++ b/packages/clients/meldemichel/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "dist/client-meldemichel.js",
   "repository": {
     "type": "git",

--- a/packages/clients/snowbox/package.json
+++ b/packages/clients/snowbox/package.json
@@ -5,7 +5,7 @@
   "keywords": ["OpenLayers", "ol", "POLAR", "client", "Snowbox", "testing"],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "scripts": {
     "build": "rimraf dist && vite build && copyfiles -f src/html/**/* dist",
     "dev": "vite --host"

--- a/packages/clients/textLocator/package.json
+++ b/packages/clients/textLocator/package.json
@@ -5,7 +5,7 @@
   "keywords": ["OpenLayers", "ol", "POLAR", "client", "TextLocator", "AI", "toponyms", "literature"],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Dataport/polar.git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -9,7 +9,7 @@
     "components"
   ],
   "license": "EUPL-1.2",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/lib/getCluster/package.json
+++ b/packages/lib/getCluster/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/packages/lib/getFeatures/package.json
+++ b/packages/lib/getFeatures/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/packages/lib/idx/package.json
+++ b/packages/lib/idx/package.json
@@ -5,7 +5,7 @@
   "keywords": ["OpenLayers", "ol", "POLAR", "lib", "getter"],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/packages/lib/invisibleStyle/package.json
+++ b/packages/lib/invisibleStyle/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/packages/lib/passesBoundaryCheck/package.json
+++ b/packages/lib/passesBoundaryCheck/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/packages/lib/testMountParameters/package.json
+++ b/packages/lib/testMountParameters/package.json
@@ -10,7 +10,7 @@
     "testing"
   ],
   "license": "EUPL-1.2",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/packages/lib/tooltip/package.json
+++ b/packages/lib/tooltip/package.json
@@ -5,7 +5,7 @@
   "keywords": ["OpenLayers", "ol", "POLAR", "lib", "tooltip"],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/AddressSearch/package.json
+++ b/packages/plugins/AddressSearch/package.json
@@ -14,7 +14,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Attributions/package.json
+++ b/packages/plugins/Attributions/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Draw/package.json
+++ b/packages/plugins/Draw/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Export/package.json
+++ b/packages/plugins/Export/package.json
@@ -15,7 +15,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Filter/package.json
+++ b/packages/plugins/Filter/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "files": [
     "src/**/*",

--- a/packages/plugins/Fullscreen/package.json
+++ b/packages/plugins/Fullscreen/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/GeoLocation/package.json
+++ b/packages/plugins/GeoLocation/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Gfi/package.json
+++ b/packages/plugins/Gfi/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/IconMenu/package.json
+++ b/packages/plugins/IconMenu/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/LayerChooser/package.json
+++ b/packages/plugins/LayerChooser/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Legend/package.json
+++ b/packages/plugins/Legend/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/LoadingIndicator/package.json
+++ b/packages/plugins/LoadingIndicator/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Pins/package.json
+++ b/packages/plugins/Pins/package.json
@@ -12,7 +12,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/ReverseGeocoder/package.json
+++ b/packages/plugins/ReverseGeocoder/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Scale/package.json
+++ b/packages/plugins/Scale/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Toast/package.json
+++ b/packages/plugins/Toast/package.json
@@ -13,7 +13,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/plugins/Zoom/package.json
+++ b/packages/plugins/Zoom/package.json
@@ -11,7 +11,7 @@
   ],
   "license": "EUPL-1.2",
   "type": "module",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "src/index.ts",
   "repository": {
     "type": "git",

--- a/packages/types/custom/package.json
+++ b/packages/types/custom/package.json
@@ -9,7 +9,7 @@
     "types"
   ],
   "license": "EUPL-1.2",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "main": "index.ts",
   "repository": {
     "type": "git",

--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -182,7 +182,7 @@ client.createMap({
     <hr>
     <h2>Contact</h2>
     <p>
-      Mail us at <a href="mailto:dataportpolarsupport@dataport.de">dataportpolarsupport@dataport.de</a>
+      Mail us at <a href="mailto:polar@dataport.de">polar@dataport.de</a>
     </p>
     <p>
       <small><a href="https://github.com/Dataport/polar/blob/main/LEGALNOTICE.md" target="_blank">Legal Notice (Impressum) ↗</a></small>

--- a/pages/index.html
+++ b/pages/index.html
@@ -213,7 +213,7 @@
     <hr class="footer-hr">
     <h2>Contact</h2>
     <p>
-      Mail us at <a href="mailto:dataportpolarsupport@dataport.de">dataportpolarsupport@dataport.de</a>
+      Mail us at <a href="mailto:polar@dataport.de">polar@dataport.de</a>
     </p>
     <p>
       <small><a href="https://github.com/Dataport/polar/blob/main/LEGALNOTICE.md" target="_blank">Legal Notice (Impressum) ↗</a></small>

--- a/pages/package.json
+++ b/pages/package.json
@@ -2,7 +2,7 @@
   "name": "polar-pages",
   "private": true,
   "description": "GitHub page for POLAR project",
-  "author": "Dataport AöR <dataportpolarsupport@dataport.de>",
+  "author": "Dataport AöR <polar@dataport.de>",
   "license": "EUPL-1.2",
   "engines": {
     "node": "^18.13.0",

--- a/security.md
+++ b/security.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-If you discover a security vulnerability within this project, please send an e-mail to dataportpolarsupport@dataport.de.
+If you discover a security vulnerability within this project, please send an e-mail to polar@dataport.de.
 
 Please include, if available, the following information in your report:
 


### PR DESCRIPTION
## Summary

Change mail from dataportpolarsupport@dataport.de to polar@dataport.de.

## Instructions for local reproduction and review

Check whether I missed something or did an oopsie.
