### PR TITLE
remove pan tooltip during drag interaction

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: If a flag `_isPolarDragLikeInteraction` is present on any interaction, the page will stop scrolling in mobile mode, and the interaction takes precendence. This flag is documented at the end of the README.md.
+
 ## 3.0.0
 
 - Breaking: Upgrade `@masterportal/masterportalapi` from `2.40.0` to `2.45.0` and subsequently `ol` from `^9.2.4` to `^10.3.1`.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unpublished
 
-- Feature: If a flag `_isPolarDragLikeInteraction` is present on any interaction, the page will stop scrolling in mobile mode, and the interaction takes precendence. This flag is documented at the end of the README.md.
+- Fix: If a flag `_isPolarDragLikeInteraction` is present on any interaction, the page will stop scrolling in mobile mode, and the interaction takes precendence. Especially, this is done to prevent the tooltip on how to pan the map on mobile devices to appear. This flag is documented at the end of the README.md.
 
 ## 3.0.0
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -547,3 +547,11 @@ You may desire to listen to whether the loader is currently being shown.
 | hovered | Feature \| null | If `useExtendedMasterportalApiMarkers` is active, this will return the currently hovered marker. Please mind that it may be a clustered feature. |
 | selected | Feature \| null | If `useExtendedMasterportalApiMarkers` is active, this will return the currently selected marker. Please mind that it may be a clustered feature. |
 | selectedCoordinates | Array \| null | If `useExtendedMasterportalApiMarkers` is active, this will return the coordinates of the currently selected marker. |
+
+## Special Flags
+
+POLAR uses flags on some OL elements to handle overarching issues. Those flags can be retrieved with `olThing.get('_flagName')`. These flags must not be specific to a plugin and must provide documentation in this place. They may yield uses outside of the POLAR application when further building upon the clients or creating new plugins.
+
+| flagName | type | description |
+| - | - | - |
+| _isPolarDragLikeInteraction | true | This flag is either `true` or absent. It must be present on drag-like interactions with the map to provide information to the core on when to display the map pan instructions on mobile devices. The instructions will not be shown if a single interaction with this flag is found, assuming that the interaction takes precendence over scrolling the page. |

--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -162,9 +162,7 @@ export default Vue.extend({
     this.mapConfiguration.locales?.forEach?.((locale: Locale) =>
       i18next.addResourceBundle(locale.type, 'common', locale.resources, true)
     )
-
     i18next.on('languageChanged', (lang) => (this.lang = lang))
-
     if (this.mapConfiguration.checkServiceAvailability) {
       this.checkServiceAvailability()
     }
@@ -173,7 +171,6 @@ export default Vue.extend({
   },
   beforeDestroy() {
     removeEventListener('resize', this.updateHasSmallDisplay)
-
     const mapContainer = this.$refs['polar-map-container']
     if (!this.hasWindowSize && mapContainer) {
       ;(mapContainer as HTMLDivElement).removeEventListener(
@@ -241,7 +238,6 @@ export default Vue.extend({
   position: absolute;
   height: 100%;
   width: 100%;
-
   .polar-map {
     width: 100%;
     height: 100%;
@@ -276,16 +272,13 @@ export default Vue.extend({
   height: 100%;
   width: 100%;
 }
-
 .v-tooltip__content {
   background-color: #595959;
   border: 2px solid #fff;
 }
-
 .v-application {
   font-family: sans-serif !important;
 }
-
 /* Override v-app default styling (must be global to take effect) */
 .polar-wrapper .v-application--wrap {
   min-height: initial;

--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -95,6 +95,7 @@ export default Vue.extend({
     ...mapGetters([
       'hasSmallWidth',
       'hasWindowSize',
+      'map',
       'moveHandle',
       'moveHandleActionButton',
     ]),
@@ -207,8 +208,18 @@ export default Vue.extend({
           window.innerWidth <= SMALL_DISPLAY_WIDTH
         ) {
           new Hammer(mapContainer).on('pan', (e) => {
-            this.oneFingerPan = e.maxPointers === 1
-            setTimeout(() => (this.oneFingerPan = false), 2000)
+            if (
+              e.maxPointers === 1 &&
+              !this.map
+                .getInteractions()
+                .getArray()
+                .some((interaction) =>
+                  interaction.get('_isPolarDragLikeInteraction')
+                )
+            ) {
+              this.oneFingerPan = true
+              setTimeout(() => (this.oneFingerPan = false), 2000)
+            }
           })
         }
       }

--- a/packages/plugins/Draw/CHANGELOG.md
+++ b/packages/plugins/Draw/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unpublished
 
 - Feature: Add a "Translate" mode that allows moving drawn features as they are.
+- Feature: Interactions requiring dragging are now marked with the POLAR flag `_isPolarDragLikeInteraction`.
 
 ## 3.0.0
 

--- a/packages/plugins/Draw/src/store/createInteractions/createModifyInteractions.ts
+++ b/packages/plugins/Draw/src/store/createInteractions/createModifyInteractions.ts
@@ -12,6 +12,7 @@ const createModify = (
   const activeContainer = { active: false }
   const features: Collection<Feature> = new Collection()
   const modify = new Modify({ features })
+  modify.set('_isPolarDragLikeInteraction', true, true)
   modify.on('modifystart', () => {
     activeContainer.active = true
   })

--- a/packages/plugins/Draw/src/store/createInteractions/createTranslateInteractions.ts
+++ b/packages/plugins/Draw/src/store/createInteractions/createTranslateInteractions.ts
@@ -12,6 +12,7 @@ const createTranslate = (
   const activeContainer = { active: false }
   const features: Collection<Feature> = new Collection()
   const translate = new Translate({ features })
+  translate.set('_isPolarDragLikeInteraction', true, true)
   translate.on('translatestart', () => {
     activeContainer.active = true
   })


### PR DESCRIPTION
## Summary

Previously, when performing drag-like operation in the Draw plugin, a tooltip would appear on mobile devices, indicating that two fingers could be used to pan the map (whilst e.h. during Translate, a polygon was moved in the background).

This issue has been resolved by introducing a new flag and flag documentation mode. Since we use this at times, this will come in handy for future extension when refactoring such flags to more abstract ones, AND they become reusable for new plugins requiring samey interactions.

## Instructions for local reproduction and review

Run the snowbox and check the behaviour on a mobile and desktop device for consistency.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [ ] ~~Functionality has been tested with 200% screen zoom~~
- [ ] ~~Screenreader functionality has been manually tested with NVDA~~

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [ ] ~~Chrome Lighthouse~~
  - [ ] ~~Firefox Accessibility~~

## Relevant tickets, issues, et cetera

Resolves: #227
