### PR TITLE
Allow layers that have singleTile: true set to be used for gfi requests

### DIFF
--- a/packages/plugins/Gfi/CHANGELOG.md
+++ b/packages/plugins/Gfi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Allow layers that have `singleTile` set to `true` and thus being an `ImageLayer` instead a `TileLayer` to be used for GFI-requests as well.
+
 ## 3.0.1
 
 - Fix: Clean-up internal flag used for `multiSelect` if a drawing is aborted. This is always the case if a user simply clicks into the map holding CTRL / Command.

--- a/packages/plugins/Gfi/src/types.ts
+++ b/packages/plugins/Gfi/src/types.ts
@@ -1,7 +1,8 @@
 import { Map, Feature } from 'ol'
 import BaseLayer from 'ol/layer/Base'
+import ImageLayer from 'ol/layer/Image'
 import TileLayer from 'ol/layer/Tile'
-import { TileWMS } from 'ol/source'
+import { ImageWMS, TileWMS } from 'ol/source'
 import VectorSource from 'ol/source/Vector'
 import { Feature as GeoJsonFeature, GeoJsonProperties } from 'geojson'
 import {
@@ -31,7 +32,7 @@ export interface RequestGfiWmsParameters {
   coordinate: [number, number]
   layerConfiguration: RequestGfiParameters['layerConfiguration']
   layerSpecification: RequestGfiParameters['layerSpecification']
-  layer: TileLayer<TileWMS>
+  layer: TileLayer<TileWMS> | ImageLayer<ImageWMS>
 }
 
 export type FeaturesByLayerId = Record<string, GeoJsonFeature[] | symbol>

--- a/packages/plugins/Gfi/src/utils/requestGfi.ts
+++ b/packages/plugins/Gfi/src/utils/requestGfi.ts
@@ -1,7 +1,8 @@
 import { Feature as GeoJsonFeature } from 'geojson'
-import { Tile as TileLayer, Vector as VectorLayer } from 'ol/layer'
+import ImageLayer from 'ol/layer/Image'
+import TileLayer from 'ol/layer/Tile'
+import VectorLayer from 'ol/layer/Vector'
 import { rawLayerList } from '@masterportal/masterportalapi'
-
 import { RequestGfiParameters } from '../types'
 
 import requestGfiWms from './requestGfiWms'
@@ -32,7 +33,7 @@ export function requestGfi({
       layerConfiguration,
       layerSpecification,
     }
-    if (layer instanceof TileLayer) {
+    if (layer instanceof TileLayer || layer instanceof ImageLayer) {
       return coordinateOrExtent.length === 2
         ? requestGfiWms({
             ...params,


### PR DESCRIPTION
## Summary

If a WMS-Layer had `singleTile` set to `true`, gfi requests were not possible as the `if`-statement only checked for `TileLayer` which is not the case for single-tiled-WMS-layers.

## Instructions for local reproduction and review

- Configure the Layer with the id `367` in `@polar/client-snowbox` for general usage and gfi
- `npm run snowbox`
- Clicking in the map should yield a result.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- ~~[ ] Screenreader functionality has been manually tested with NVDA~~

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - ~~[ ] Chrome Lighthouse~~
  - ~~[ ] Firefox Accessibility~~

## Relevant tickets, issues, et cetera

None
