### PR TITLE
add xtrasse to diplan client

### DIFF
--- a/packages/clients/diplan/example/config.js
+++ b/packages/clients/diplan/example/config.js
@@ -3,6 +3,7 @@ const basemap = 'basemapde_farbe'
 const xplanwms = 'xplanwms'
 const xplanwfs = 'xplanwfs'
 const flurstuecke = 'flurstuecke'
+const bstgasleitung = 'bst_gasleitung'
 
 export default {
   startResolution: 264.583190458,
@@ -20,12 +21,14 @@ export default {
             [xplanwms]: 'XPlanWMS',
             [xplanwfs]: 'XPlanSynWFS',
             [flurstuecke]: 'Flurstücke',
+            [bstgasleitung]: 'BST Gasleitung',
           },
           attributions: {
             [basemap]: `$t(diplan.layers.${basemap}) © GeoBasis-DE / BKG <YEAR> CC BY 4.0`,
             [xplanwms]: `$t(diplan.layers.${xplanwms}) © ???`,
             [xplanwfs]: `$t(diplan.layers.${xplanwfs}) © ???`,
             [flurstuecke]: `$t(diplan.layers.${flurstuecke}) © ???`,
+            [bstgasleitung]: `$t(diplan.layers.${bstgasleitung}) © ???`,
           },
         },
       },
@@ -75,6 +78,12 @@ export default {
       type: 'mask',
       name: `diplan.layers.${flurstuecke}`,
     },
+    {
+      id: bstgasleitung,
+      visibility: false,
+      type: 'mask',
+      name: `diplan.layers.${bstgasleitung}`,
+    },
   ],
   attributions: {
     layerAttributions: [
@@ -93,6 +102,10 @@ export default {
       {
         id: flurstuecke,
         title: `diplan.attributions.${flurstuecke}`,
+      },
+      {
+        id: bstgasleitung,
+        title: `diplan.attributions.${bstgasleitung}`,
       },
     ],
   },

--- a/packages/clients/diplan/example/services.js
+++ b/packages/clients/diplan/example/services.js
@@ -451,4 +451,13 @@ export default [
     crs: 'http://www.opengis.net/def/crs/EPSG/0/25832',
     bboxCrs: 'http://www.opengis.net/def/crs/EPSG/0/25832',
   },
+  {
+    id: 'bst_gasleitung',
+    typ: 'OAF',
+    name: 'bst_gasleitung',
+    url: 'https://xtrasse.ldproxy.develop.diplanung.de/xtrasse_PFS_gas',
+    collection: 'bst_gasleitung',
+    crs: 'http://www.opengis.net/def/crs/EPSG/0/25832',
+    bboxCrs: 'http://www.opengis.net/def/crs/EPSG/0/25832',
+  },
 ]


### PR DESCRIPTION
## Summary

Configured an OAF layer as test for XTrasse data.

https://xtrasse.ldproxy.develop.diplanung.de/xtrasse_PFS_gas/collections/bst_gasleitung/items

## Instructions for local reproduction and review

Run `npm run diplan:dev` and check the environment near Wilhelmshaven for line geometries when the newly configured OAF layer is turned on.
