### PR TITLE
Feature/bgw custom search function

### DIFF
--- a/packages/clients/bgw/src/addPlugins.ts
+++ b/packages/clients/bgw/src/addPlugins.ts
@@ -13,7 +13,10 @@ import Scale from '@polar/plugin-scale'
 import Toast from '@polar/plugin-toast'
 import Zoom from '@polar/plugin-zoom'
 import merge from 'lodash.merge'
-import { badestellenSearchResult } from './utils/badestellenSearch'
+import {
+  badestellenSearch,
+  badestellenSearchResult,
+} from './utils/badestellenSearch'
 
 const defaultOptions = {
   displayComponent: true,
@@ -75,6 +78,7 @@ export default (core) => {
       merge({}, defaultOptions, {
         addLoading: 'plugin/loadingIndicator/addLoadingKey',
         removeLoading: 'plugin/loadingIndicator/removeLoadingKey',
+        customSearchMethods: { badestellenSearch },
         customSelectResult: { badestellen: badestellenSearchResult },
       })
     ),

--- a/packages/clients/bgw/src/mapConfiguration.ts
+++ b/packages/clients/bgw/src/mapConfiguration.ts
@@ -126,7 +126,7 @@ const mapConfig = {
       {
         groupId: 'badestellenSearch',
         categoryId: 'badestellen',
-        type: 'wfs',
+        type: 'badestellenSearch',
         url: 'https://umweltgeodienste.schleswig-holstein.de/WFS_BGW',
         queryParameters: {
           srsName: 'EPSG:25832',

--- a/packages/clients/bgw/src/utils/badestellenSearch.ts
+++ b/packages/clients/bgw/src/utils/badestellenSearch.ts
@@ -1,10 +1,26 @@
-import { SelectResultFunction } from '@polar/lib-custom-types'
+import { Feature } from 'geojson'
+import {
+  CoreGetters,
+  CoreState,
+  PolarStore,
+  SelectResultFunction,
+} from '@polar/lib-custom-types'
 import {
   SearchResultSymbols,
   AddressSearchGetters,
   AddressSearchState,
 } from '@polar/plugin-address-search'
-import { Feature } from 'geojson'
+import { WfsParameters, getWfsFeatures } from '@polar/lib-get-features'
+
+export function badestellenSearch(
+  this: PolarStore<CoreState, CoreGetters>,
+  signal: AbortSignal,
+  url: string,
+  inputValue: string,
+  queryParameters: WfsParameters
+) {
+  return getWfsFeatures(signal, url, inputValue.toUpperCase(), queryParameters)
+}
 
 export const badestellenSearchResult: SelectResultFunction<
   AddressSearchState,

--- a/packages/clients/bgw/src/utils/badestellenSearch.ts
+++ b/packages/clients/bgw/src/utils/badestellenSearch.ts
@@ -12,6 +12,14 @@ import {
 } from '@polar/plugin-address-search'
 import { WfsParameters, getWfsFeatures } from '@polar/lib-get-features'
 
+function replaceUmlauts(input: string): string {
+  return input
+    .replace(/Ä/g, 'AE')
+    .replace(/Ö/g, 'OE')
+    .replace(/Ü/g, 'UE')
+    .replace(/ß/g, 'SS')
+}
+
 export function badestellenSearch(
   this: PolarStore<CoreState, CoreGetters>,
   signal: AbortSignal,
@@ -19,7 +27,7 @@ export function badestellenSearch(
   inputValue: string,
   queryParameters: WfsParameters
 ) {
-  const searchString = inputValue.toUpperCase() as string
+  const searchString = replaceUmlauts(inputValue.toUpperCase())
   return getWfsFeatures(signal, url, `*${searchString}*`, queryParameters)
 }
 

--- a/packages/clients/bgw/src/utils/badestellenSearch.ts
+++ b/packages/clients/bgw/src/utils/badestellenSearch.ts
@@ -19,7 +19,8 @@ export function badestellenSearch(
   inputValue: string,
   queryParameters: WfsParameters
 ) {
-  return getWfsFeatures(signal, url, inputValue.toUpperCase(), queryParameters)
+  const searchString = inputValue.toUpperCase() as string
+  return getWfsFeatures(signal, url, `*${searchString}*`, queryParameters)
 }
 
 export const badestellenSearchResult: SelectResultFunction<


### PR DESCRIPTION
## Summary

Add custom search to improve search results of bathing areas. User now can find "OSTS;FLENSBURGER AUSSENFOERDE" when searchinfg for "Außenförde".

## Instructions for local reproduction and review

Start the bgw client and switch to the "Badestellensuche". Then enter at least three letters, e.g. "kiel".

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained - **the client has not been published yet so there isn't a new entry.** 
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
