### PR TITLE
Feature/highlight expansion by clicking on bathing area

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17951,6 +17951,7 @@
       "peerDependencies": {
         "@repositoryname/vuex-generators": "^1.1.2",
         "lodash.merge": "^4.6.2",
+        "ol": "^10.3.1",
         "vue": "^2.x",
         "vuex": "^3.x"
       }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "pages:build:serve": "http-server pages -o index.html",
     "clean": "nx reset && rimraf --glob packages/**/{.cache,dist,docs} && rimraf --glob {.cache,dist} && node ./scripts/clean",
     "docs:afm": "tsx ./scripts/makeDocs afm",
-    "docs:bgw": "tsx ./scripts/makeDocs bgw",
     "docs:diplan": "npm run diplan:build && cp -r ./packages/clients/diplan/dist ./packages/clients/diplan/example ./packages/clients/diplan/docs",
     "docs:generic": "tsx ./scripts/makeDocs generic",
     "docs:meldemichel": "tsx ./scripts/makeDocs meldemichel && npm run meldemichel:build && cp -r ./packages/clients/meldemichel/dist ./packages/clients/meldemichel/example ./packages/clients/meldemichel/docs",

--- a/packages/clients/bgw/README.md
+++ b/packages/clients/bgw/README.md
@@ -15,7 +15,7 @@ Usage as a HTML page is simply offered by hosting the client package with the in
 | fieldName | type | description |
 | - | - | - |
 | infoFields | object[] | Array of key-label pair objects. The property of the feature that should be displayed has to be set as `key`. The description of this property has to be set as `label`. |
-| highlightStyleBadestraende | object with attributes `stroke` and / or `fill`| highlight style for the layer 'Badestraende'. |
+| highlightStyleBadestraende | highlightStyleBadestraende? | Highlight style for the layer 'Badestraende'. |
 
 ### Example configuration:
 
@@ -32,6 +32,19 @@ infoFields: [
 ],
 highlightStyleBadestraende: {
   stroke: { color: '#FF4500', width: 10 },
-  fill: { color: '#FF0000'},
-},
+}
+```
+
+### gfi.highlightStyleBadestraende
+
+| fieldName | type | description |
+| - | - | - |
+| stroke | stroke | Stroke style for the layer 'Badestraende'. Please see example below for styling options. |
+
+####  Example configuration:
+
+```js
+highlightStyleBadestraende: {
+  stroke: { color: '#FF4500', width: 10 },
+}
 ```

--- a/packages/clients/bgw/README.md
+++ b/packages/clients/bgw/README.md
@@ -15,6 +15,7 @@ Usage as a HTML page is simply offered by hosting the client package with the in
 | fieldName | type | description |
 | - | - | - |
 | infoFields | object[] | Array of key-label pair objects. The property of the feature that should be displayed has to be set as `key`. The description of this property has to be set as `label`. |
+| highlightStyleBadestraende | object with attributes `stroke` and / or `fill`| highlight style for the layer 'Badestraende'. |
 
 ### Example configuration:
 
@@ -29,4 +30,8 @@ infoFields: [
   { key: 'bgw_laenge_bgw', label: 'Länge Uferlinie (m)'},
   { key: 'bgw_umfeld', label: 'Umfeld (m)' },
 ],
+highlightStyleBadestraende: {
+  stroke: { color: '#FF4500', width: 10 },
+  fill: { color: '#FF0000'},
+},
 ```

--- a/packages/clients/bgw/package.json
+++ b/packages/clients/bgw/package.json
@@ -45,6 +45,7 @@
     "@repositoryname/vuex-generators": "^1.1.2",
     "vue": "^2.x",
     "vuex": "^3.x",
+    "ol": "^10.3.1",
     "lodash.merge": "^4.6.2"
   },
   "nx": {

--- a/packages/clients/bgw/package.json
+++ b/packages/clients/bgw/package.json
@@ -14,7 +14,6 @@
   },
   "files": [
     "dist/**/**.*",
-    "docs/**/**.*",
     "CHANGELOG.md",
     "README.md"
   ],

--- a/packages/clients/bgw/src/mapConfiguration.ts
+++ b/packages/clients/bgw/src/mapConfiguration.ts
@@ -250,6 +250,9 @@ const mapConfig = {
       },
       { key: 'bgw_umfeld', label: 'plugins.gfi.infoLabels.bgw_umfeld' },
     ],
+    highlightStyleBadestraende: {
+      stroke: { color: '#FF4500', width: 10 },
+    },
   },
   featureStyles: './style.json',
 }

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -46,9 +46,7 @@ export default Vue.extend({
   components: { ActionButton },
   data: () => ({
     infoFields: [],
-    defaultStyle: new Style({
-      stroke: new Stroke({ color: '#FF4500', width: 3 }),
-    }),
+    defaultStyle: {} as Style,
     highlightStyle: new Style({
       stroke: new Stroke({ color: '#FF4500', width: 10 }),
     }),
@@ -73,6 +71,15 @@ export default Vue.extend({
   },
   mounted() {
     this.infoFields = this.configuration.gfi.infoFields
+    this.defaultStyle =
+      this.getBadeStellenFeatures(
+        this.map,
+        '14001',
+        this.currentProperties.fid
+      )[0].getStyle() ||
+      new Style({
+        stroke: new Stroke({ color: '#FF4500', width: 3 }),
+      })
     this.updateBadestraendeStyles(
       this.currentProperties.fid,
       this.highlightStyle

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -37,7 +37,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapActions, mapGetters } from 'vuex'
-import { Stroke, Style } from 'ol/style'
+import { Fill, Stroke, Style } from 'ol/style'
 import { Feature } from 'ol'
 import ActionButton from './ActionButton.vue'
 
@@ -47,9 +47,7 @@ export default Vue.extend({
   data: () => ({
     infoFields: [],
     defaultStyle: {} as Style,
-    highlightStyle: new Style({
-      stroke: new Stroke({ color: '#FF4500', width: 10 }),
-    }),
+    highlightStyle: {} as Style,
     badestraendeFeatures: [] as Feature[],
   }),
   computed: {
@@ -71,6 +69,16 @@ export default Vue.extend({
   },
   mounted() {
     this.infoFields = this.configuration.gfi.infoFields
+    this.highlightStyle =
+      new Style({
+        stroke: new Stroke(
+          this.configuration.gfi.highlightStyleBadestraende.stroke
+        ),
+        fill: new Fill(this.configuration.gfi.highlightStyleBadestraende.fill),
+      }) ||
+      new Style({
+        stroke: new Stroke({ color: '#FF4500', width: 10 }),
+      })
     this.defaultStyle =
       this.getBadeStellenFeatures(
         this.map,

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -69,29 +69,8 @@ export default Vue.extend({
   },
   mounted() {
     this.infoFields = this.configuration.gfi.infoFields
-    this.highlightStyle =
-      new Style({
-        stroke: new Stroke(
-          this.configuration.gfi.highlightStyleBadestraende.stroke
-        ),
-        fill: new Fill(this.configuration.gfi.highlightStyleBadestraende.fill),
-      }) ||
-      new Style({
-        stroke: new Stroke({ color: '#FF4500', width: 10 }),
-      })
-    this.defaultStyle =
-      this.getBadeStellenFeatures(
-        this.map,
-        '14001',
-        this.currentProperties.fid
-      )[0].getStyle() ||
-      new Style({
-        stroke: new Stroke({ color: '#FF4500', width: 3 }),
-      })
-    this.updateBadestraendeStyles(
-      this.currentProperties.fid,
-      this.highlightStyle
-    )
+    this.setHighlightStyle()
+    this.setDefaultStyle()
   },
   methods: {
     ...mapActions('plugin/gfi', ['close']),
@@ -119,6 +98,35 @@ export default Vue.extend({
       if (this.badestraendeFeatures.length > 0) {
         this.badestraendeFeatures.forEach((feature) => feature.setStyle(style))
       }
+    },
+    setHighlightStyle() {
+      this.highlightStyle =
+        new Style({
+          stroke: new Stroke(
+            this.configuration.gfi.highlightStyleBadestraende.stroke
+          ),
+          fill: new Fill(
+            this.configuration.gfi.highlightStyleBadestraende.fill
+          ),
+        }) ||
+        new Style({
+          stroke: new Stroke({ color: '#FF4500', width: 10 }),
+        })
+    },
+    setDefaultStyle() {
+      this.defaultStyle =
+        this.getBadeStellenFeatures(
+          this.map,
+          '14001',
+          this.currentProperties.fid
+        )[0].getStyle() ||
+        new Style({
+          stroke: new Stroke({ color: '#FF4500', width: 3 }),
+        })
+      this.updateBadestraendeStyles(
+        this.currentProperties.fid,
+        this.highlightStyle
+      )
     },
   },
 })

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -34,7 +34,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapActions, mapGetters } from 'vuex'
-import { Fill, Stroke, Style } from 'ol/style'
+import { Stroke, Style } from 'ol/style'
 import { Feature } from 'ol'
 import ActionButton from './ActionButton.vue'
 
@@ -110,9 +110,6 @@ export default Vue.extend({
         new Style({
           stroke: new Stroke(
             this.configuration.gfi.highlightStyleBadestraende.stroke
-          ),
-          fill: new Fill(
-            this.configuration.gfi.highlightStyleBadestraende.fill
           ),
         }) ||
         new Style({

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -43,9 +43,7 @@ export default Vue.extend({
   components: { ActionButton },
   data: () => ({
     infoFields: [],
-    defaultStyle: new Style({
-      stroke: new Stroke({ color: '#FF4500', width: 3 }),
-    }),
+    defaultStyle: {} as Style,
     highlightStyle: {} as Style,
     badestraendeFeatures: [] as Feature[],
   }),
@@ -69,6 +67,7 @@ export default Vue.extend({
   },
   mounted() {
     this.infoFields = this.configuration.gfi.infoFields
+    this.setDefaultStyle(this.map, '14001')
     this.updateBadestraendeStyles(null, this.defaultStyle)
     this.setHighlightStyle()
     this.updateBadestraendeStyles(
@@ -118,6 +117,17 @@ export default Vue.extend({
         }) ||
         new Style({
           stroke: new Stroke({ color: '#FF4500', width: 10 }),
+        })
+    },
+    setDefaultStyle(map, layerId) {
+      const layer = map
+        .getLayers()
+        .getArray()
+        .find((layer) => layer.get('id') === layerId)
+      this.defaultStyle =
+        layer.getStyle() ||
+        new Style({
+          stroke: new Stroke({ color: '#FF4500', width: 3 }),
         })
     },
   },

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -43,11 +43,14 @@ export default Vue.extend({
   components: { ActionButton },
   data: () => ({
     infoFields: [],
-    defaultStyle: {} as Style,
+    defaultStyle: new Style({
+      stroke: new Stroke({ color: '#FF4500', width: 3 }),
+    }),
     highlightStyle: {} as Style,
     badestraendeFeatures: [] as Feature[],
   }),
   computed: {
+    ...mapGetters(['selected']),
     ...mapGetters(['map', 'configuration']),
     ...mapGetters('plugin/gfi', ['currentProperties']),
     ...mapGetters(['hasSmallWidth', 'hasWindowSize']),
@@ -66,11 +69,15 @@ export default Vue.extend({
   },
   mounted() {
     this.infoFields = this.configuration.gfi.infoFields
+    this.updateBadestraendeStyles(null, this.defaultStyle)
     this.setHighlightStyle()
-    this.setDefaultStyle()
+    this.updateBadestraendeStyles(
+      this.currentProperties.fid,
+      this.highlightStyle
+    )
   },
   beforeDestroy() {
-    this.updateBadestraendeStyles(null, this.defaultStyle)
+    if (!this.selected) this.updateBadestraendeStyles(null, this.defaultStyle)
   },
   methods: {
     ...mapActions('plugin/gfi', ['close']),
@@ -112,21 +119,6 @@ export default Vue.extend({
         new Style({
           stroke: new Stroke({ color: '#FF4500', width: 10 }),
         })
-    },
-    setDefaultStyle() {
-      this.defaultStyle =
-        this.getBadeStellenFeatures(
-          this.map,
-          '14001',
-          this.currentProperties.fid
-        )[0].getStyle() ||
-        new Style({
-          stroke: new Stroke({ color: '#FF4500', width: 3 }),
-        })
-      this.updateBadestraendeStyles(
-        this.currentProperties.fid,
-        this.highlightStyle
-      )
     },
   },
 })

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -106,15 +106,11 @@ export default Vue.extend({
       }
     },
     setHighlightStyle() {
-      this.highlightStyle =
-        new Style({
-          stroke: new Stroke(
-            this.configuration.gfi.highlightStyleBadestraende.stroke
-          ),
-        }) ||
-        new Style({
-          stroke: new Stroke({ color: '#FF4500', width: 10 }),
-        })
+      this.highlightStyle = new Style({
+        stroke: new Stroke(
+          this.configuration.gfi.highlightStyleBadestraende.stroke
+        ),
+      })
     },
     setDefaultStyle(map, layerId) {
       const layer = map

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -1,8 +1,5 @@
 <template>
-  <v-card
-    v-if="infoFields.length > 0 && currentProperties"
-    class="bgw-gfi-content"
-  >
+  <v-card v-if="info.length > 0 && currentProperties" class="bgw-gfi-content">
     <v-card-actions v-if="!hasWindowSize || !hasSmallWidth">
       <v-spacer></v-spacer>
       <v-btn
@@ -34,92 +31,24 @@
 <script lang="ts">
 import Vue from 'vue'
 import { mapActions, mapGetters } from 'vuex'
-import { Stroke, Style } from 'ol/style'
-import { Feature } from 'ol'
 import ActionButton from './ActionButton.vue'
 
 export default Vue.extend({
   name: 'BgwGfiContent',
   components: { ActionButton },
-  data: () => ({
-    infoFields: [],
-    defaultStyle: {} as Style,
-    highlightStyle: {} as Style,
-    badestraendeFeatures: [] as Feature[],
-  }),
   computed: {
-    ...mapGetters(['selected']),
-    ...mapGetters(['map', 'configuration']),
+    ...mapGetters([
+      'map',
+      'configuration',
+      'selected',
+      'hasSmallWidth',
+      'hasWindowSize',
+    ]),
     ...mapGetters('plugin/gfi', ['currentProperties']),
-    ...mapGetters(['hasSmallWidth', 'hasWindowSize']),
-    info(): Array<string[]> {
-      return this.infoFields.map(({ key, label }) => [
-        label,
-        this.currentProperties[key],
-      ])
-    },
-  },
-  watch: {
-    currentProperties(value) {
-      this.updateBadestraendeStyles(this.defaultStyle)
-      this.updateBadestraendeFeature(value.fid)
-      this.updateBadestraendeStyles(this.highlightStyle)
-    },
-  },
-  mounted() {
-    this.infoFields = this.configuration.gfi.infoFields
-    this.setDefaultStyle(this.map, '14001')
-    this.updateBadestraendeStyles(this.defaultStyle)
-    this.setHighlightStyle()
-    this.updateBadestraendeFeature(this.currentProperties.fid)
-    this.updateBadestraendeStyles(this.highlightStyle)
-  },
-  beforeDestroy() {
-    if (!this.selected) this.updateBadestraendeStyles(this.defaultStyle)
+    ...mapGetters('bgw', ['info']),
   },
   methods: {
     ...mapActions('plugin/gfi', ['close']),
-    getBadeStellenFeatures(map, layerId: string, badeStellenId: string) {
-      const layer = map
-        .getLayers()
-        .getArray()
-        .find((layer) => layer.get('id') === layerId)
-
-      return layer
-        .getSource()
-        .getFeatures()
-        .filter((feature) => {
-          return feature.get('BATHINGWAT') === badeStellenId
-        })
-    },
-    updateBadestraendeFeature(id) {
-      this.badestraendeFeatures = this.getBadeStellenFeatures(
-        this.map,
-        '14001',
-        id
-      )
-    },
-    updateBadestraendeStyles(style: Style) {
-      this.badestraendeFeatures.forEach((feature) => feature.setStyle(style))
-    },
-    setHighlightStyle() {
-      this.highlightStyle = new Style({
-        stroke: new Stroke(
-          this.configuration.gfi.highlightStyleBadestraende.stroke
-        ),
-      })
-    },
-    setDefaultStyle(map, layerId) {
-      const layer = map
-        .getLayers()
-        .getArray()
-        .find((layer) => layer.get('id') === layerId)
-      this.defaultStyle =
-        layer.getStyle() ||
-        new Style({
-          stroke: new Stroke({ color: '#FF4500', width: 3 }),
-        })
-    },
   },
 })
 </script>

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -11,7 +11,7 @@
         :aria-label="$t('plugins.gfi.header.close')"
         @click="
           close(true)
-          updateFeatureStyles(null, defaultStyle)
+          updateBadestraendeStyles(null, defaultStyle)
         "
       >
         <v-icon small>fa-xmark</v-icon>
@@ -67,13 +67,16 @@ export default Vue.extend({
   },
   watch: {
     currentProperties(value) {
-      this.updateFeatureStyles(null, this.defaultStyle)
-      this.updateFeatureStyles(value.fid, this.highlightStyle)
+      this.updateBadestraendeStyles(null, this.defaultStyle)
+      this.updateBadestraendeStyles(value.fid, this.highlightStyle)
     },
   },
   mounted() {
     this.infoFields = this.configuration.gfi.infoFields
-    this.updateFeatureStyles(this.currentProperties.fid, this.highlightStyle)
+    this.updateBadestraendeStyles(
+      this.currentProperties.fid,
+      this.highlightStyle
+    )
   },
   methods: {
     ...mapActions('plugin/gfi', ['close']),
@@ -90,7 +93,7 @@ export default Vue.extend({
           return feature.get('BATHINGWAT') === badeStellenId
         })
     },
-    updateFeatureStyles(id: string | null, style: Style) {
+    updateBadestraendeStyles(id: string | null, style: Style) {
       if (id) {
         this.badestraendeFeatures = this.getBadeStellenFeatures(
           this.map,

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -9,10 +9,7 @@
         icon
         small
         :aria-label="$t('plugins.gfi.header.close')"
-        @click="
-          close(true)
-          updateBadestraendeStyles(null, defaultStyle)
-        "
+        @click="close(true)"
       >
         <v-icon small>fa-xmark</v-icon>
       </v-btn>
@@ -71,6 +68,9 @@ export default Vue.extend({
     this.infoFields = this.configuration.gfi.infoFields
     this.setHighlightStyle()
     this.setDefaultStyle()
+  },
+  beforeDestroy() {
+    this.updateBadestraendeStyles(null, this.defaultStyle)
   },
   methods: {
     ...mapActions('plugin/gfi', ['close']),

--- a/packages/clients/bgw/src/plugins/Gfi/Content.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/Content.vue
@@ -61,22 +61,21 @@ export default Vue.extend({
   },
   watch: {
     currentProperties(value) {
-      this.updateBadestraendeStyles(null, this.defaultStyle)
-      this.updateBadestraendeStyles(value.fid, this.highlightStyle)
+      this.updateBadestraendeStyles(this.defaultStyle)
+      this.updateBadestraendeFeature(value.fid)
+      this.updateBadestraendeStyles(this.highlightStyle)
     },
   },
   mounted() {
     this.infoFields = this.configuration.gfi.infoFields
     this.setDefaultStyle(this.map, '14001')
-    this.updateBadestraendeStyles(null, this.defaultStyle)
+    this.updateBadestraendeStyles(this.defaultStyle)
     this.setHighlightStyle()
-    this.updateBadestraendeStyles(
-      this.currentProperties.fid,
-      this.highlightStyle
-    )
+    this.updateBadestraendeFeature(this.currentProperties.fid)
+    this.updateBadestraendeStyles(this.highlightStyle)
   },
   beforeDestroy() {
-    if (!this.selected) this.updateBadestraendeStyles(null, this.defaultStyle)
+    if (!this.selected) this.updateBadestraendeStyles(this.defaultStyle)
   },
   methods: {
     ...mapActions('plugin/gfi', ['close']),
@@ -93,17 +92,15 @@ export default Vue.extend({
           return feature.get('BATHINGWAT') === badeStellenId
         })
     },
-    updateBadestraendeStyles(id: string | null, style: Style) {
-      if (id) {
-        this.badestraendeFeatures = this.getBadeStellenFeatures(
-          this.map,
-          '14001',
-          id
-        )
-      }
-      if (this.badestraendeFeatures.length > 0) {
-        this.badestraendeFeatures.forEach((feature) => feature.setStyle(style))
-      }
+    updateBadestraendeFeature(id) {
+      this.badestraendeFeatures = this.getBadeStellenFeatures(
+        this.map,
+        '14001',
+        id
+      )
+    },
+    updateBadestraendeStyles(style: Style) {
+      this.badestraendeFeatures.forEach((feature) => feature.setStyle(style))
     },
     setHighlightStyle() {
       this.highlightStyle = new Style({

--- a/packages/clients/bgw/src/polar-client.ts
+++ b/packages/clients/bgw/src/polar-client.ts
@@ -3,6 +3,7 @@ import packageInfo from '../package.json'
 import addPlugins from './addPlugins'
 import services from './services'
 import mapConfiguration from './mapConfiguration'
+import bgwModule from './store/module'
 
 // eslint-disable-next-line no-console
 console.info(`@polar/client-bgw: running in v${packageInfo.version}.`)
@@ -13,13 +14,16 @@ addPlugins(client)
 async function initializeClient() {
   client.rawLayerList.initializeLayerList(services)
 
-  await client.createMap({
+  const clientInstance = await client.createMap({
     containerId,
     mapConfiguration: {
       ...mapConfiguration,
       layerConf: services,
     },
   })
+
+  clientInstance.$store.registerModule('bgw', bgwModule)
+  clientInstance.$store.dispatch('bgw/setupModule')
 }
 
 initializeClient()

--- a/packages/clients/bgw/src/store/module.ts
+++ b/packages/clients/bgw/src/store/module.ts
@@ -1,0 +1,66 @@
+import { PolarModule } from '@polar/lib-custom-types'
+import { Stroke, Style } from 'ol/style'
+
+interface BgwGetters {
+  info: string[][]
+  highlightStyle: Style
+}
+
+/*
+ * BGW VueX Store Module
+ */
+const bgwModule: PolarModule<Record<string, never>, BgwGetters> = {
+  namespaced: true,
+  state: {},
+  actions: {
+    setupModule({ rootGetters, dispatch }) {
+      this.watch(
+        () => rootGetters['plugin/gfi/currentProperties'],
+        () => dispatch('updateFeatures'),
+        { deep: true }
+      )
+    },
+    // handles style side effects
+    updateFeatures({ rootGetters, getters }) {
+      const currentProperties = rootGetters['plugin/gfi/currentProperties']
+
+      const features = rootGetters.map
+        .getLayers()
+        .getArray()
+        .find((layer) => layer.get('id') === '14001')
+        // @ts-expect-error | it exists on its deviations
+        ?.getSource()
+        .getFeatures()
+
+      features.forEach((feature) =>
+        feature.setStyle(
+          feature.get('BATHINGWAT') === currentProperties.fid
+            ? getters.highlightStyle
+            : undefined
+        )
+      )
+    },
+  },
+  mutations: {},
+  getters: {
+    info(_, __, ___, rootGetters) {
+      // @ts-expect-error | local piggyback
+      return (rootGetters.configuration.gfi?.infoFields || []).map(
+        ({ key, label }) => [
+          label,
+          rootGetters['plugin/gfi/currentProperties'][key],
+        ]
+      )
+    },
+    highlightStyle(_, __, ___, rootGetters) {
+      return new Style({
+        stroke: new Stroke(
+          // @ts-expect-error | local piggyback
+          rootGetters.configuration.gfi?.highlightStyleBadestraende.stroke
+        ),
+      })
+    },
+  },
+}
+
+export default bgwModule

--- a/scripts/buildPages.sh
+++ b/scripts/buildPages.sh
@@ -1,4 +1,4 @@
-array=( afm bgw diplan generic meldemichel snowbox textLocator )
+array=( afm diplan generic meldemichel snowbox textLocator )
 for i in "${array[@]}"
 do
   echo "Building $i docs ..."


### PR DESCRIPTION
## Summary

When clicking on a bathing area in the Badegewässer client, the bathing area expansion is highlighted. When clicking on another bathing area or when closing the gfi, the highlighting of the previously selected area is removed.

## Instructions for local reproduction and review

Start the Badegewässer client and click on a bathing area marker. The orange line displaying the bathing area expansion will be highlighted by displaying a thicker line. The highlighting style is set to default if another bathing area is selected or if the gfi is closed.

Sometimes bathing areas are composed of two or more linestrings. To test this, search for "OSTS;GELINGER BUCHT" for example.

EDIT: I checked the emulation for mobile devices in Firefox and realized that the highlighting was not removed, so I adjusted the code accordingly. It should work now, but you might want to check this on an actual mobile phone. 

EDIT EDIT: User can now change tools in iconMenu without deleting the highlighting when a feature is still selected. There might still be a bug which is due to the `select` getter not deselecting when closing the gfi on mobile devices (= the marker stays red and the highlighting is not removed).

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained - **the client has not been published yet so there isn't a new entry.**
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
