### PR TITLE
delete link to bgw-docs

### DIFF
--- a/pages/documentation.html
+++ b/pages/documentation.html
@@ -94,7 +94,6 @@
       <p>Each client comes with its own documentation built from its individual description and used plugins.</p>
       <ul>
         <li><a href="./docs/afm/client-afm.html" target="_blank">AfM documentation ↗</a> (used in OSI/OZG context)</li>
-        <li><a href="./docs/bgw/client-bgw.html" target="_blank">Badegewässer documentation ↗</a></li>
         <li><a href="./docs/diplan/client-diplan.html" target="_blank">DiPlan documentation ↗</a></li>
         <li><a href="./docs/generic/client-generic.html" target="_blank">Generic documentation ↗</a></li>
         <li><a href="./docs/meldemichel/client-meldemichel.html" target="_blank">Meldemichel documentation ↗</a></li>


### PR DESCRIPTION
## Summary

Link to no-existing Badegewässer Client Docs has been deleted because.

## Instructions for local reproduction and review

## Pull Request Checklist (for Assignee)

- [x ] Changelogs are maintained - **no changelog entry necessary for this**
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
