### PR TITLE
ignore legends for some background layers

### DIFF
--- a/packages/clients/dish/src/services.ts
+++ b/packages/clients/dish/src/services.ts
@@ -48,6 +48,7 @@ const dop20ColService = {
   format: 'image/png',
   version: '1.3.0',
   transparent: true,
+  legendURL: 'ignore',
 }
 
 const bddColService = {
@@ -60,6 +61,7 @@ const bddColService = {
   format: 'image/png',
   version: '1.3.0',
   transparent: true,
+  legendURL: 'ignore',
 }
 
 const bddEinService = {
@@ -72,6 +74,7 @@ const bddEinService = {
   format: 'image/png',
   version: '1.3.0',
   transparent: true,
+  legendURL: 'ignore',
 }
 
 const servicesExtern = [


### PR DESCRIPTION
## Summary

The legend display for all background layers despite basemap has been deactivated. This is a reset to the original configuration due to customer wishes.

## Instructions for local reproduction and review

Start the DISH client in mode `extern` and check the legend display.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained - **no real change so no changlog entry**
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
