### PR TITLE
implement geometry cloning

### DIFF
--- a/packages/clients/diplan/example/dev/index.html
+++ b/packages/clients/diplan/example/dev/index.html
@@ -33,7 +33,7 @@
             <legend>DiPlan-Funktionen</legend>
             <button id="action-lasso">Lasso-Funktion</button>
             <button id="action-cut-polygons">Cut polygons</button>
-            <button id="action-duplicate-polygons">Duplicate polygons</button>
+            <button id="action-duplicate-geometry">Duplicate geometry</button>
             <button id="action-merge-polygons">Merge polygons</button>
           </fieldset>
           <div>Active extended draw mode: <span id="active-draw-mode"></span></div>

--- a/packages/clients/diplan/example/dev/setup.js
+++ b/packages/clients/diplan/example/dev/setup.js
@@ -66,7 +66,7 @@ export default (client, layerConf, config) => {
       const actionLasso = document.getElementById('action-lasso')
       const actionCut = document.getElementById('action-cut-polygons')
       const actionDuplicate = document.getElementById(
-        'action-duplicate-polygons'
+        'action-duplicate-geometry'
       )
       const actionMerge = document.getElementById('action-merge-polygons')
       const activeExtendedDrawMode = document.getElementById('active-draw-mode')

--- a/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
+++ b/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
@@ -39,7 +39,7 @@ export const duplicatePolygons = ({
   const boundPointerStyle = pointerStyle(rootGetters.map, drawLayer)
   rootGetters.map.on('pointermove', boundPointerStyle)
 
-  selectedFeatures.on(['add'], () => {
+  selectedFeatures.on('add', () => {
     drawSource.addFeature(selectedFeatures.getArray()[0].clone())
     selectedFeatures.clear()
     dispatch('updateDrawMode', null)

--- a/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
+++ b/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
@@ -5,7 +5,7 @@ import { Map } from 'ol'
 import { DiplanGetters, DiplanState } from '../../types'
 
 const pointerStyle = (map: Map, drawLayer: VectorLayer) => (e) => {
-  const found = map.forEachFeatureAtPixel(e.pixel, () => true, {
+  const found = map.hasFeatureAtPixel(e.pixel, {
     layerFilter: (l) => l === drawLayer,
   })
 

--- a/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
+++ b/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
@@ -1,5 +1,4 @@
 import { PolarActionContext } from '@polar/lib-custom-types'
-
 import VectorLayer from 'ol/layer/Vector'
 import { Select } from 'ol/interaction'
 import { Map } from 'ol'

--- a/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
+++ b/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
@@ -1,22 +1,56 @@
 import { PolarActionContext } from '@polar/lib-custom-types'
+
+import VectorLayer from 'ol/layer/Vector'
+import { Select } from 'ol/interaction'
+import { Map } from 'ol'
 import { DiplanGetters, DiplanState } from '../../types'
 
+const pointerStyle = (map: Map, drawLayer: VectorLayer) => (e) => {
+  const found = map.forEachFeatureAtPixel(e.pixel, () => true, {
+    layerFilter: (l) => l === drawLayer,
+  })
+
+  if (found) {
+    map.getTargetElement().setAttribute('style', 'cursor: copy')
+  } else {
+    map.getTargetElement().setAttribute('style', '')
+  }
+}
+
 export const duplicatePolygons = ({
-  commit,
   dispatch,
+  rootGetters,
 }: PolarActionContext<DiplanState, DiplanGetters>) => {
-  dispatch('plugin/draw/setMode', 'none', { root: true })
-  commit('setDrawMode', 'duplicate')
+  dispatch('updateDrawMode', 'duplicate')
 
-  dispatch(
-    'plugin/toast/addToast',
-    {
-      type: 'info',
-      text: 'Duplicate not yet implemented.',
-      timeout: 3000,
-    },
-    { root: true }
-  )
+  const drawSource = rootGetters['plugin/draw/drawSource']
+  const drawLayer = rootGetters.map
+    .getLayers()
+    .getArray()
+    .find(
+      (layer) =>
+        layer instanceof VectorLayer && layer.getSource() === drawSource
+    ) as VectorLayer
+  const selectInteraction = new Select({ layers: [drawLayer] })
+  const selectedFeatures = selectInteraction.getFeatures()
+  // TODO temp solution, not actually _isDeleteSelect; normalizing these flags is part of a future effort
+  // @ts-expect-error | internal hack to detect it in @polar/plugin-pins and @polar/plugin-gfi
+  selectInteraction._isDeleteSelect = true
 
-  // TODO on end: commit('setDrawMode', null)
+  const boundPointerStyle = pointerStyle(rootGetters.map, drawLayer)
+  rootGetters.map.on('pointermove', boundPointerStyle)
+
+  selectedFeatures.on(['add'], () => {
+    drawSource.addFeature(selectedFeatures.getArray()[0].clone())
+    selectedFeatures.clear()
+    dispatch('updateDrawMode', null)
+  })
+
+  // @ts-expect-error | local piggyback
+  selectInteraction._onRemove = () => {
+    rootGetters.map.un('pointermove', boundPointerStyle)
+    rootGetters.map.getTargetElement().setAttribute('style', '')
+  }
+
+  dispatch('plugin/draw/setInteractions', [selectInteraction], { root: true })
 }


### PR DESCRIPTION
## Summary

The "Duplicate polygon" button is now a broader "Duplicate geometry" button. It does what is says and shows its availability to do so with a "copy" cursor.

Blocks on https://github.com/Dataport/polar/pull/263

## Instructions for local reproduction and review

`npm run diplan:dev`, draw some geometries and clone them.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari ← @dopenguin please test on MacOS
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [ ] ~~Screenreader functionality has been manually tested with NVDA~~ doesn't apply, actual UI will come in different PR

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [ ] ~~Chrome Lighthouse~~ doesn't apply, actual UI will come in different PR
  - [ ] ~~Firefox Accessibility~~ doesn't apply, actual UI will come in different PR
