### PR TITLE
remove peer dependencies from diplan

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18254,12 +18254,6 @@
         "just-compare": "^2.3.0",
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.2"
-      },
-      "peerDependencies": {
-        "@repositoryname/vuex-generators": "^1.1.2",
-        "ol": "^10.3.1",
-        "vue": "^2.x",
-        "vuex": "^3.x"
       }
     },
     "packages/clients/dish": {

--- a/packages/clients/diplan/package.json
+++ b/packages/clients/diplan/package.json
@@ -61,12 +61,6 @@
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.2"
   },
-  "peerDependencies": {
-    "@repositoryname/vuex-generators": "^1.1.2",
-    "ol": "^10.3.1",
-    "vue": "^2.x",
-    "vuex": "^3.x"
-  },
   "nx": {
     "includedScripts": [
       "build",


### PR DESCRIPTION
## Summary

Modeled DiPlan client without the peer dependencies since the leading system does not use `--legacy-peer-deps` and versions brought in with this installation would possibly stay in conflict with other installations there. Since POLAR comes pre-bundled, it's pointless for them to know anyway. The packages are not peer from their point of view.

## Instructions for local reproduction and review

Not much. Might check whether it still works after reinstall.
