### PR TITLE
disable automatic full interaction end on first end

### DIFF
--- a/packages/clients/diplan/example/polar-ui/index.html
+++ b/packages/clients/diplan/example/polar-ui/index.html
@@ -17,17 +17,27 @@
         <h2 class="padded-x">Beispielinstanz</h2>
         <div class="padded-x">
           <h3>Steuerung von außen</h3>
-          <button id="action-plus">+</button>
-          <button id="action-minus">-</button>
-          <button id="action-toast">Toast</button>
-          <button id="action-load-geojson">GeoJSON hinzufügen</button>
-          <button id="action-zoom-to-all">Zoome auf Zeichnung</button>
-          <button id="action-lasso">Lasso-Funktion</button>
-          <label>
-            Adresssuche (erstbestes Ergebnis):
-            <input id="action-address-search-filler"/>
-          </label>
-          <br/>
+          <fieldset>
+            <legend>POLAR-Standardfunktionen</legend>
+            <button id="action-plus">+</button>
+            <button id="action-minus">-</button>
+            <button id="action-toast">Toast</button>
+            <button id="action-load-geojson">GeoJSON hinzufügen</button>
+            <button id="action-zoom-to-all">Zoome auf Zeichnung</button>
+            <label>
+              Adresssuche (erstbestes Ergebnis):
+              <input id="action-address-search-filler"/>
+            </label>
+          </fieldset>
+          <fieldset>
+            <legend>DiPlan-Funktionen</legend>
+            <button id="action-none">Aktive Funktion ausschalten</button>
+            <button id="action-lasso">Lasso-Funktion</button>
+            <button id="action-cut-polygons">Cut polygons</button>
+            <button id="action-duplicate-geometry">Duplicate geometry</button>
+            <button id="action-merge-polygons">Merge polygons</button>
+          </fieldset>
+          <div>Active extended draw mode: <span id="active-draw-mode"></span></div>
         </div>
         <h3 class="padded-x">Klient</h3>
         <div id="polarstern">

--- a/packages/clients/diplan/example/polar-ui/setup.js
+++ b/packages/clients/diplan/example/polar-ui/setup.js
@@ -55,6 +55,13 @@ export default (client, layerConf, config) => {
         'action-address-search-filler'
       )
       const actionLasso = document.getElementById('action-lasso')
+      const actionNone = document.getElementById('action-none')
+      const actionCut = document.getElementById('action-cut-polygons')
+      const actionDuplicate = document.getElementById(
+        'action-duplicate-geometry'
+      )
+      const actionMerge = document.getElementById('action-merge-polygons')
+      const activeExtendedDrawMode = document.getElementById('active-draw-mode')
 
       actionPlus.onclick = () =>
         mapInstance.$store.dispatch('plugin/zoom/increaseZoomLevel')
@@ -83,6 +90,19 @@ export default (client, layerConf, config) => {
       )
       actionLasso.onclick = () =>
         mapInstance.$store.dispatch('plugin/draw/setMode', 'lasso')
+      actionCut.onclick = () =>
+        mapInstance.$store.dispatch('diplan/cutPolygons')
+      actionDuplicate.onclick = () =>
+        mapInstance.$store.dispatch('diplan/duplicatePolygons')
+      actionMerge.onclick = () =>
+        mapInstance.$store.dispatch('diplan/mergePolygons')
+      actionNone.onclick = () =>
+        mapInstance.$store.dispatch('diplan/updateDrawMode', null)
+      mapInstance.$store.watch(
+        (_, getters) => getters['diplan/activeDrawMode'],
+        (activeDrawMode) => (activeExtendedDrawMode.innerHTML = activeDrawMode),
+        { immediate: true }
+      )
 
       const htmlRevisedDrawExport = document.getElementById(
         'subscribed-revised-draw-export'

--- a/packages/clients/diplan/src/store/geoEditing/cutPolygons/index.ts
+++ b/packages/clients/diplan/src/store/geoEditing/cutPolygons/index.ts
@@ -69,7 +69,6 @@ export const cutPolygons = ({
         { root: true }
       )
     }
-    dispatch('updateDrawMode', null)
   })
 
   dispatch('plugin/draw/setInteractions', [draw], { root: true })

--- a/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
+++ b/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
@@ -42,7 +42,6 @@ export const duplicatePolygons = ({
   selectedFeatures.on('add', () => {
     drawSource.addFeature(selectedFeatures.getArray()[0].clone())
     selectedFeatures.clear()
-    dispatch('updateDrawMode', null)
   })
 
   // @ts-expect-error | local piggyback

--- a/packages/clients/diplan/src/store/geoEditing/mergePolygons.ts
+++ b/packages/clients/diplan/src/store/geoEditing/mergePolygons.ts
@@ -58,8 +58,6 @@ export const mergePolygons = ({
 
     drawSource.clear()
     drawSource.addFeatures(nextFeatures)
-
-    dispatch('updateDrawMode', null)
   })
 
   dispatch(

--- a/packages/plugins/Draw/src/store/createInteractions/createLassoInteractions.ts
+++ b/packages/plugins/Draw/src/store/createInteractions/createLassoInteractions.ts
@@ -82,8 +82,6 @@ export default function ({
   // should be fine, line bloat is from error handling (only logging/toasting)
   // eslint-disable-next-line max-lines-per-function
   draw.on('drawend', (e) => {
-    dispatch('setMode', 'none')
-
     const toast = (toastObject) =>
       getters.toastAction &&
       dispatch(getters.toastAction, toastObject, { root: true })


### PR DESCRIPTION
## Summary

The methods cutPolygon/mergePolygon/duplicatePolygon are no longer turned off after the first `drawend` of the Draw method. Instead, they now work until intentionally disabled.

The `/polar-ui` example has been extended to showcase these functions and allows turning them off manually.

## Instructions for local reproduction and review

Check `/polar-ui` example in build mode.
