### PR TITLE
fix minZoom for layers to work from minZoom on

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Feature: Additionally export `MapInstance` type.
 - Feature: Add possibility of using OIDC secured services by using the configuration parameters `secureServiceUrlRegex` and `oidcToken` as well as the mutation `setOidcToken`.
 - Fix: If a flag `_isPolarDragLikeInteraction` is present on any interaction, the page will stop scrolling in mobile mode, and the interaction takes precendence. Especially, this is done to prevent the tooltip on how to pan the map on mobile devices to appear. This flag is documented at the end of the README.md.
+- Fix: Vector layers were loaded one zoom level too late despite being available for activation. This has been resolved. The POLAR values for `minZoom` and `maxZoom` on layers are both modeled to be inclusive now.
 
 ## 3.0.0
 

--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -44,6 +44,8 @@
 </template>
 
 <script lang="ts">
+// it's complex, can't really be helped
+/* eslint-disable max-lines */
 import Vue, { PropType } from 'vue'
 import { mapActions, mapGetters, mapMutations } from 'vuex'
 import api from '@masterportal/masterportalapi/src/maps/api'
@@ -59,6 +61,7 @@ import {
 import { SMALL_DISPLAY_HEIGHT, SMALL_DISPLAY_WIDTH } from '../utils/constants'
 import { addClusterStyle } from '../utils/addClusterStyle'
 import { setupStyling } from '../utils/setupStyling'
+import { mapZoomOffset } from '../utils/mapZoomOffset'
 import MapUi from './MapUi.vue'
 // NOTE: OpenLayers styles need to be imported as the map resides in the shadow DOM
 import 'ol/ol.css'
@@ -135,9 +138,11 @@ export default Vue.extend({
     const map = api.map.createMap(
       {
         target: this.$refs['polar-map-container'],
-        ...(this.mapConfiguration.extendedMasterportalapiMarkers
-          ? addClusterStyle(this.mapConfiguration)
-          : this.mapConfiguration),
+        ...mapZoomOffset(
+          this.mapConfiguration.extendedMasterportalapiMarkers
+            ? addClusterStyle(this.mapConfiguration)
+            : this.mapConfiguration
+        ),
       },
       '2D',
       {

--- a/packages/core/src/utils/mapZoomOffset.ts
+++ b/packages/core/src/utils/mapZoomOffset.ts
@@ -1,0 +1,26 @@
+import { MapConfig } from '@polar/lib-custom-types'
+
+/**
+ * NOTE This is a workaround addressing the recent change in `minZoom` logic in
+ * the `@masterportal/masterportalapi`. Previously, the `minZoom` would be used
+ * to decide for a resolution, which was inclusive, but now `minZoom` is
+ * forwarded, which is exclusive.
+ *
+ * To avoid breaking changes, we're simply mapping the `minZoom` before
+ * forwarding the configuration to the value usage intended in POLAR; that is,
+ * inclusive.
+ */
+export const mapZoomOffset = (mapConfiguration: MapConfig): MapConfig => {
+  if (mapConfiguration.layers) {
+    return {
+      ...mapConfiguration,
+      layers: mapConfiguration.layers.map((entry) => {
+        if (typeof entry.minZoom !== 'undefined') {
+          return { ...entry, minZoom: entry.minZoom - 1 }
+        }
+        return entry
+      }),
+    }
+  }
+  return mapConfiguration
+}

--- a/packages/plugins/LayerChooser/CHANGELOG.md
+++ b/packages/plugins/LayerChooser/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Chore: The documentation for `minZoom` and `maxZoom` has been updated regarding their inclusive interpretation of the zoom value.
+
 ## 2.0.0
 
 - Breaking: Upgrade `@masterportal/masterportalapi` from `2.40.0` to `2.45.0` and subsequently `ol` from `^9.2.4` to `^10.3.1`.

--- a/packages/plugins/LayerChooser/README.md
+++ b/packages/plugins/LayerChooser/README.md
@@ -20,8 +20,8 @@ Also, this plugin also supports the optional configuration parameters `mapConfig
 | - | - | - |
 | type | enum["background", "mask"] | Layer handling. Backgrounds are mutually exclusive, masks ("overlays") can be stacked. |
 | hideInMenu | boolean? | Can be set for layers of type `'mask'` to hide them in the selection menu. |
-| maxZoom | number? | If set, layer only available (and selectable) up to this zoom level. |
-| minZoom | number? | If set, layer only available (and selectable) from this zoom level on. |
+| maxZoom | number? | If set, layer only available (and selectable) up to this zoom level, inclusively. |
+| minZoom | number? | If set, layer only available (and selectable) from this zoom level on, inclusively. |
 | options | options? | Shows a layer-specific sub-menu; its contents are configurable. |
 | visibility | boolean? | Initial visibility. Defaults to `false`. |
 


### PR DESCRIPTION
## Summary

`minZoom` was wrong by one zoom level due to a change in parameter forwarding in the `@masterportal/masterportalapi`. This has been resolved by mapping the value for the masterportalapi appropriately. No changes regarding the usage in POLAR have been made, the parameter is still meant inclusively on our end. This is to avoid the breaking changes in all configurations using it.

## Instructions for local reproduction and review

Run e.g. `diplan:dev` to see the change in effect.
