### PR TITLE
prevent snapping to invisible layers

### DIFF
--- a/packages/plugins/Draw/CHANGELOG.md
+++ b/packages/plugins/Draw/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## unpublished
 
 - Feature: Add a `"translate"` mode that allows moving drawn features as they are.
-- Feature: Add a `"snapTo"` key to the configuration that allows defining vector layers to snap to while drawing, editing, and translating.
+- Feature: Add a `"snapTo"` key to the configuration that allows defining vector layers to snap to while drawing, editing, and translating. Snapping will only pertain to configured layers while they're visible.
 - Feature: Add a lasso mode that allows copying up features from a vector layer that are contained within the user's hand drawn polygon. This also adds the fields `addLoading`, `removeLoading`, and `toastAction` for usage in the `lassos`.
 - Feature: Interactions requiring dragging are now marked with the POLAR flag `_isPolarDragLikeInteraction`.
 - Feature: Show a "pointer" cursor when the delete interaction would delete a feature on click.

--- a/packages/plugins/Draw/src/store/createInteractions/getSnaps.ts
+++ b/packages/plugins/Draw/src/store/createInteractions/getSnaps.ts
@@ -5,14 +5,19 @@ import VectorSource from 'ol/source/Vector'
 
 export const getSnaps = (map: Map, snapIds: string[]): Snap[] =>
   snapIds.reduce((accumulator, layerId) => {
-    const source = (
-      map
-        .getLayers()
-        .getArray()
-        .find((layer) => layer.get('id') === layerId) as VectorLayer
-    )?.getSource?.()
+    const layer = map
+      .getLayers()
+      .getArray()
+      .find((layer) => layer.get('id') === layerId) as VectorLayer
+    const source = layer?.getSource?.()
     if (source instanceof VectorSource) {
-      accumulator.push(new Snap({ source }))
+      const snap = new Snap({ source })
+      const visibilityToggler = () => snap.setActive(layer.getVisible())
+      layer.on('propertychange', visibilityToggler)
+      visibilityToggler()
+      // @ts-expect-error | riding piggyback
+      snap._onRemove = () => layer.un('propertychange', visibilityToggler)
+      accumulator.push(snap)
     } else {
       console.warn(
         `@polar/plugin-draw: Layer with ID "${layerId}" configured for 'snapTo', but it has no source to snap to. The layer does probably not hold any vector data.`


### PR DESCRIPTION
## Summary

The `snapTo` configuration has been changed to stop snapping to the layers while they're invisible.

## Instructions for local reproduction and review

E.g. `diplan:dev` can be used to verify that interactions no longer snap to parcels while they're invisible.
