### PR TITLE
repair handling of duplicate polygon points

### DIFF
--- a/packages/clients/diplan/src/store/updateState/index.ts
+++ b/packages/clients/diplan/src/store/updateState/index.ts
@@ -48,8 +48,9 @@ export const updateState = async ({
       (accumulator, feature) => {
         if (['Polygon', 'MultiPolygon'].includes(feature.geometry.type)) {
           accumulator.push(
-            ...unkinkPolygon(feature as GeoJsonFeature<Polygon | MultiPolygon>)
-              .features
+            ...unkinkPolygon(
+              cleanCoords(feature) as GeoJsonFeature<Polygon | MultiPolygon>
+            ).features
           )
         } else {
           accumulator.push(feature)
@@ -64,14 +65,6 @@ export const updateState = async ({
   if (getters.configuration.mergeToMultiGeometries) {
     // TODO: turf provides "union" and "combine" methods, probably just use them
     revisedFeatureCollection = mergeToMultiGeometries(revisedFeatureCollection)
-  }
-
-  // removes duplicate points from polygons
-  revisedFeatureCollection = {
-    ...revisedFeatureCollection,
-    features: revisedFeatureCollection.features.map((feature) =>
-      cleanCoords(feature)
-    ),
   }
 
   if (getters.configuration.validateGeoJson) {


### PR DESCRIPTION
## Summary

It was previously possible to produce errors by manually modifying a Polygon so that multiple of its points were on the same coordinate.

1. Draw coordinate with 4 vertices
2. Move third vertex onto second
3. Look at error in console; diplan export stopped updating

To fix this, the order of operations has been adjusted. Coordinates are now cleaned prior to further handling by methods that expect clean coordinates.

## Instructions for local reproduction and review

Verify functionality in `diplan:dev`.
