### PR TITLE
fix duplicate polygon style

### DIFF
--- a/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
+++ b/packages/clients/diplan/src/store/geoEditing/duplicatePolygons.ts
@@ -30,7 +30,7 @@ export const duplicatePolygons = ({
       (layer) =>
         layer instanceof VectorLayer && layer.getSource() === drawSource
     ) as VectorLayer
-  const selectInteraction = new Select({ layers: [drawLayer] })
+  const selectInteraction = new Select({ layers: [drawLayer], style: null })
   const selectedFeatures = selectInteraction.getFeatures()
   // TODO temp solution, not actually _isDeleteSelect; normalizing these flags is part of a future effort
   // @ts-expect-error | internal hack to detect it in @polar/plugin-pins and @polar/plugin-gfi


### PR DESCRIPTION
## Summary

Previously, duplicated geometries would sometimes have the OL default select style in build mode that did not appear in dev mode. This has been resolved and now works as expected in both modes.

## Instructions for local reproduction and review

Validate in build mode of diplan client.
