### PR TITLE
Fix issue of addInterceptor not having access yet to the regex

### DIFF
--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -134,7 +134,9 @@ export default Vue.extend({
     },
   },
   mounted() {
-    this.addInterceptor()
+    if (this.mapConfiguration.secureServiceUrlRegex) {
+      this.addInterceptor(this.mapConfiguration.secureServiceUrlRegex)
+    }
     const map = api.map.createMap(
       {
         target: this.$refs['polar-map-container'],

--- a/packages/core/src/vuePlugins/actions/addInterceptor.ts
+++ b/packages/core/src/vuePlugins/actions/addInterceptor.ts
@@ -4,33 +4,31 @@ import {
   PolarActionContext,
 } from '@polar/lib-custom-types'
 
-export function addInterceptor({
-  getters,
-}: PolarActionContext<CoreState, CoreGetters>) {
-  const { secureServiceUrlRegex } = getters.configuration
+export function addInterceptor(
+  { getters }: PolarActionContext<CoreState, CoreGetters>,
+  secureServiceUrlRegex: string
+) {
   const { fetch: originalFetch } = window
 
-  if (secureServiceUrlRegex) {
-    // If interceptors for XMLHttpRequest or axios are needed, add them here
-    window.fetch = (resource, originalConfig) => {
-      let config = originalConfig
+  // If interceptors for XMLHttpRequest or axios are needed, add them here
+  window.fetch = (resource, originalConfig) => {
+    let config = originalConfig
 
-      if (
-        getters.oidcToken &&
-        typeof resource === 'string' &&
-        resource.match(secureServiceUrlRegex)
-      ) {
-        config = {
-          ...originalConfig,
-          headers: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            Authorization: `Bearer ${getters.oidcToken}`,
-            ...originalConfig?.headers,
-          },
-        }
+    if (
+      getters.oidcToken &&
+      typeof resource === 'string' &&
+      resource.match(secureServiceUrlRegex)
+    ) {
+      config = {
+        ...originalConfig,
+        headers: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          Authorization: `Bearer ${getters.oidcToken}`,
+          ...originalConfig?.headers,
+        },
       }
-
-      return originalFetch(resource, config)
     }
+
+    return originalFetch(resource, config)
   }
 }


### PR DESCRIPTION
## Summary

The store was not completely initialized so the regular expression was not yet added to the store. This PR fixes that by adding it as a parameter to the aciton.

## Instructions for local reproduction and review

`npm run diplan:dev` & use the patch I provided you. The layer should load again
