### PR TITLE
Add a layer group for xplan layers in @polar/client-diplan

### DIFF
--- a/packages/clients/diplan/example/diplan-ui-one/config.js
+++ b/packages/clients/diplan/example/diplan-ui-one/config.js
@@ -106,13 +106,13 @@ export default {
     {
       id: xplanwms,
       visibility: true,
-      type: 'mask',
+      type: 'xplan',
       name: `diplan.layers.${xplanwms}`,
     },
     {
       id: xplanwfs,
       visibility: false,
-      type: 'mask',
+      type: 'xplan',
       name: `diplan.layers.${xplanwfs}`,
     },
     {

--- a/packages/clients/diplan/example/diplan-ui-two/config.js
+++ b/packages/clients/diplan/example/diplan-ui-two/config.js
@@ -107,13 +107,13 @@ export default {
     {
       id: xplanwms,
       visibility: true,
-      type: 'mask',
+      type: 'xplan',
       name: `diplan.layers.${xplanwms}`,
     },
     {
       id: xplanwfs,
       visibility: false,
-      type: 'mask',
+      type: 'xplan',
       name: `diplan.layers.${xplanwfs}`,
     },
     {

--- a/packages/clients/diplan/src/config.js
+++ b/packages/clients/diplan/src/config.js
@@ -103,13 +103,13 @@ export default {
     {
       id: xplanwms,
       visibility: true,
-      type: 'mask',
+      type: 'xplan',
       name: `diplan.layers.${xplanwms}`,
     },
     {
       id: xplanwfs,
       visibility: false,
-      type: 'mask',
+      type: 'xplan',
       name: `diplan.layers.${xplanwfs}`,
     },
     {

--- a/packages/clients/diplan/src/locales.ts
+++ b/packages/clients/diplan/src/locales.ts
@@ -37,6 +37,9 @@ export const diplanDe = {
         geoEditing: 'Digitalisierungswerkzeuge',
       },
     },
+    layerChooser: {
+      xplanTitle: 'XPlanGML',
+    },
   },
 } as const
 

--- a/packages/clients/diplan/src/plugins/LayerChooser/LayerWrapper.vue
+++ b/packages/clients/diplan/src/plugins/LayerChooser/LayerWrapper.vue
@@ -28,7 +28,7 @@ export default Vue.extend({
     },
     disabledLayers: {
       type: Array,
-      required: true,
+      default: () => [],
     },
     layerId: {
       type: String,


### PR DESCRIPTION
## Summary

Add an additional layer type `xplan` for the LayerChooser in `@polar/client-diplan`.

## Instructions for local reproduction and review

`npm run diplan:dev` and see the new category in the LayerChooser

## Pull Request Checklist (for Assignee)

- [ ] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility
