### PR TITLE
Fix/diplan spa rerender

### DIFF
--- a/packages/clients/diplan/API.md
+++ b/packages/clients/diplan/API.md
@@ -148,3 +148,17 @@ mapInstance.$store.watch(
   }
 )
 ```
+
+## Rerender hints
+
+In some SPA applications, the map client may produce unexpected behaviour on rerenders. Should this still occur in `1.0.0-beta.1` or later, please try these methods:
+
+* Use `mapInstance.$destroy()` in your framework's lifecycle's unmount method before new `createMap` calls.
+* In general, your calls to our `watch` or `subscribe` methods should also be cleaned up to avoid leaks. These methods return `unwatch` or `unsubscribe` methods respectively, and can be called on any cleanup.
+* Most frameworks will handle DOM regeneration on rerenders themselves. Should you need to clean up the DOM for arbitrary reasons yourself, this snippet may come in handy:
+  ```js
+    const polarstern = document.getElementById('polarstern-wrapper')
+    const stellamaris = document.createElement('div')
+    stellamaris.id = 'polarstern'
+    polarstern?.parentElement?.replaceChild(stellamaris, polarstern)
+  ```

--- a/packages/clients/diplan/CHANGELOG.md
+++ b/packages/clients/diplan/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: The DiPlan client previously produced redundant plugins on rerenders. This issue has been resolved. The usage for this solution can be viewn in the example `diplan-ui-one`, with additional notes at the end of the `API.md`.
+
 ## 1.0.0-beta.0
 
 Beta release with MVP state for integration test.

--- a/packages/clients/diplan/example/diplan-ui-one/index.html
+++ b/packages/clients/diplan/example/diplan-ui-one/index.html
@@ -43,7 +43,7 @@
           </fieldset>
           <div>Active extended draw mode: <span id="active-draw-mode"></span></div>
         </div>
-        <h3 class="padded-x">Klient</h3>
+        <h3 class="padded-x">Klient <button onclick="resetup(false)">rerender</button><button onclick="resetup(true)">rerenderSmall</button></h3>
         <div id="polarstern">
           <noscript>Bitte benutzen Sie einen Browser mit aktiviertem JavaScript, um den Kartenklienten zu nutzen.</noscript>
         </div>
@@ -120,9 +120,37 @@
       import diplanMapClient from '../../dist/client-diplan.js'
       import services from '../services.js'
       import config from './config.js'
-      import setup from './setup.js'
+      import configSmall from '../diplan-ui-small/config.js'
+      import { setup, setdown } from './setup.js'
+      import setupSmall from '../diplan-ui-small/setup.js'
 
       setup(diplanMapClient, services, config)
+
+      // removeEventlistener, undo subscriptions, etc. – whenever you invoke `subscribe` or `watch` on our instance/store, an unwatch/-subscribe method is returned that should be used on e.g. unmount
+      let nextSetdown = setdown
+
+      window.resetup = (small) => {
+        window.mapInstance.$destroy()
+        setdown?.()
+        nextSetdown = null
+
+        const polarstern = document.getElementById('polarstern-wrapper')
+        const stellamaris = document.createElement('div')
+        stellamaris.id = 'polarstern'
+        polarstern?.parentElement?.replaceChild(stellamaris, polarstern)
+
+        if (small) {
+          setupSmall(diplanMapClient, services, configSmall)
+            .then(() => document
+              .getElementById('polarstern-wrapper')
+              .setAttribute('style', 'height: 300px; width: 300px; margin: 0 auto')
+            )
+        }
+        else {
+          setup(diplanMapClient, services, config)
+          nextSetdown = setdown
+        }
+      }
     </script>
   </body>
 </html>

--- a/packages/clients/diplan/example/diplan-ui-small/setup.js
+++ b/packages/clients/diplan/example/diplan-ui-small/setup.js
@@ -1,7 +1,7 @@
 /* this is an example setup function displaying how POLAR is instantiated
  * you may do this in any other format as long as all required contents arrive
  * in `createMap` */
-export default (client, layerConf, config) => {
+export default (client, layerConf, config) =>
   client
     .createMap(
       {
@@ -20,4 +20,3 @@ export default (client, layerConf, config) => {
     .then((mapInstance) => {
       window.mapInstance = mapInstance
     })
-}

--- a/packages/clients/diplan/src/polar-client.ts
+++ b/packages/clients/diplan/src/polar-client.ts
@@ -27,6 +27,7 @@ const diplanCore = { ...core }
 
 export default {
   createMap: (properties, mode: keyof typeof MODE) => {
+    diplanCore.resetPlugins() // cleanup for previous instances, if any
     addPlugins(diplanCore, mode)
     return diplanCore
       .createMap(

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Default core export now contains a `resetPlugins` method that allows undoing all previous `addPlugins` calls.
+
 ## 3.1.0
 
 - Feature: Add `singleTile` as as usable parameter in the configuration of WMS-layers.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import * as mpapi from '@masterportal/masterportalapi'
-import addPlugins from './utils/addPlugins'
+import addPlugins, { resetPlugins } from './utils/addPlugins'
 import createMap from './utils/createMap'
 
 // NOTE: This is needed to be able to properly use the export
@@ -16,12 +16,14 @@ export type { MapInstance } from './types'
 export type PolarCore = typeof mpapi & {
   // TODO add more
   addPlugins: typeof addPlugins
+  resetPlugins: typeof resetPlugins
   createMap: typeof createMap
 }
 
 const core: PolarCore = {
   ...mpapi,
   addPlugins,
+  resetPlugins,
   createMap,
 }
 

--- a/packages/core/src/utils/addPlugins.ts
+++ b/packages/core/src/utils/addPlugins.ts
@@ -1,5 +1,10 @@
+let initialCreateMap = null
+
 export default function addPlugins(this, plugins) {
   const originalCreateMap = this.createMap
+  if (!initialCreateMap) {
+    initialCreateMap = originalCreateMap
+  }
   this.createMap = async (params) => {
     try {
       const instance = await originalCreateMap(params)
@@ -8,5 +13,12 @@ export default function addPlugins(this, plugins) {
     } catch (error) {
       console.error('@polar/core: Map creation failed.', error)
     }
+  }
+}
+
+export function resetPlugins(this) {
+  if (initialCreateMap) {
+    this.createMap = initialCreateMap
+    initialCreateMap = null
   }
 }

--- a/packages/core/src/vuePlugins/vuex.ts
+++ b/packages/core/src/vuePlugins/vuex.ts
@@ -102,7 +102,7 @@ export const makeStore = () => {
   let moveHandle: MoveHandleProperties | null = null
   let moveHandleActionButton: MoveHandleActionButton | null = null
   let selected: null | Feature = null
-  let components = []
+  let components: PluginContainer[] = []
   let interactions: Interaction[] = []
 
   const setCenter = ({ map }) =>


### PR DESCRIPTION
## Summary

SPA applications were sometimes showing duplicate plugins. This has been resolved.

## Instructions for local reproduction and review

`npm run diplan:build && npm run diplan:build:serve`'s example `one` illustrates rerenders now working with different configurations and plugin sets.
