### PR TITLE
fix diplan export example

### DIFF
--- a/packages/clients/diplan/example/diplan-ui-one/index.html
+++ b/packages/clients/diplan/example/diplan-ui-one/index.html
@@ -29,6 +29,7 @@
             <button id="action-toast">Toast</button>
             <button id="action-load-geojson">GeoJSON hinzufügen</button>
             <button id="action-zoom-to-all">Zoome auf Zeichnung</button>
+            <button id="action-screenshot">Screenshot erstellen (siehe Tabelle unten)</button>
             <label>
               Adresssuche (erstbestes Ergebnis):
               <input id="action-address-search-filler"/>
@@ -78,7 +79,7 @@
             <tr>
               <td><code>plugin/export/exportedMap</code></td>
               <td><a id="subscribed-export-a" download="polar_screenshot.png" href=""><img id="subscribed-export-img" /></a></td>
-              <td>Screenshot des aktuellen Kartenausschnitts. Produzierbar durch Klick auf den unteren linken "Export"-Button.</td>
+              <td>Screenshot des aktuellen Kartenausschnitts. Produzierbar durch Klick auf den Screenshot-Button über der Karte, der einen programmatischen Aufruf simuliert. Alternativ kann auch ein Button in der Karte eingeblendet werden.</td>
             </tr>
             <tr>
               <td><code>plugin/zoom/zoomLevel</code></td>
@@ -94,21 +95,6 @@
               <td><code>plugin/draw/featureCollection</code></td>
               <td id="subscribed-draw">uninitialized</td>
               <td>Die hergestellte Zeichnung als GeoJSON (ohne diplanspezifische Metainformationen und Modifikationen).</td>
-            </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-a">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
-            </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-b">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
-            </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-c">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
             </tr>
           </tbody>
         </table>

--- a/packages/clients/diplan/example/diplan-ui-one/setup.js
+++ b/packages/clients/diplan/example/diplan-ui-one/setup.js
@@ -64,9 +64,12 @@ export const setup = (client, layerConf, config) => {
       const actionDuplicate = document.getElementById(
         'action-duplicate-polygons'
       )
+      const actionScreenshot = document.getElementById('action-screenshot')
       const actionMerge = document.getElementById('action-merge-polygons')
       const activeExtendedDrawMode = document.getElementById('active-draw-mode')
 
+      actionScreenshot.onclick = () =>
+        mapInstance.$store.dispatch('plugin/export/exportAs', 'Png')
       actionPlus.onclick = () =>
         mapInstance.$store.dispatch('plugin/zoom/increaseZoomLevel')
       unsubscriptions.push(() => actionPlus.removeAttribute('onclick'))
@@ -124,6 +127,8 @@ export const setup = (client, layerConf, config) => {
       const htmlRevisedDrawExport = document.getElementById(
         'subscribed-revised-draw-export'
       )
+      const htmlExportA = document.getElementById('subscribed-export-a')
+      const htmlExportImg = document.getElementById('subscribed-export-img')
       const htmlRevisionInProgress = document.getElementById(
         'subscribed-revision-in-progress'
       )
@@ -178,6 +183,12 @@ export const setup = (client, layerConf, config) => {
             htmlSimpleGeometryValidity.innerHTML = simpleGeometryValidity
           }
         )
+      )
+      unsubscriptions.push(
+        mapInstance.subscribe('plugin/export/exportedMap', (img) => {
+          htmlExportA.setAttribute('href', img)
+          htmlExportImg.setAttribute('src', img)
+        })
       )
 
       window.mapInstance = mapInstance

--- a/packages/clients/diplan/example/diplan-ui-two/index.html
+++ b/packages/clients/diplan/example/diplan-ui-two/index.html
@@ -76,11 +76,6 @@
               <td>Simple-Geometry-Konformität</td>
             </tr>
             <tr>
-              <td><code>plugin/export/exportedMap</code></td>
-              <td><a id="subscribed-export-a" download="polar_screenshot.png" href=""><img id="subscribed-export-img" /></a></td>
-              <td>Screenshot des aktuellen Kartenausschnitts. Produzierbar durch Klick auf den unteren linken "Export"-Button.</td>
-            </tr>
-            <tr>
               <td><code>plugin/zoom/zoomLevel</code></td>
               <td id="subscribed-zoom">uninitialized</td>
               <td>Zoomstufe der <a target="_blank" href="https://openlayers.org/en/latest/apidoc/module-ol_View-View.html#getZoom">OpenLayers/View</a> als <code>Number</code></td>
@@ -94,21 +89,6 @@
               <td><code>plugin/draw/featureCollection</code></td>
               <td id="subscribed-draw">uninitialized</td>
               <td>Die hergestellte Zeichnung als GeoJSON (ohne diplanspezifische Metainformationen und Modifikationen).</td>
-            </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-a">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
-            </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-b">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
-            </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-c">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
             </tr>
           </tbody>
         </table>

--- a/packages/clients/diplan/example/polar-ui/index.html
+++ b/packages/clients/diplan/example/polar-ui/index.html
@@ -24,7 +24,6 @@
             <button id="action-toast">Toast</button>
             <button id="action-load-geojson">GeoJSON hinzufügen</button>
             <button id="action-zoom-to-all">Zoome auf Zeichnung</button>
-            <button id="action-screenshot">Screenshot erstellen (siehe Tabelle unten)</button>
             <label>
               Adresssuche (erstbestes Ergebnis):
               <input id="action-address-search-filler"/>
@@ -71,11 +70,6 @@
               <td><code>diplan/simpleGeometryValidity</code></td>
               <td id="subscribed-simple-geometry-validity">uninitialized</td>
               <td>Simple-Geometry-Konformität</td>
-            </tr>
-            <tr>
-              <td><code>plugin/export/exportedMap</code></td>
-              <td><a id="subscribed-export-a" download="polar_screenshot.png" href=""><img id="subscribed-export-img" /></a></td>
-              <td>Screenshot des aktuellen Kartenausschnitts. Produzierbar durch Klick auf den unteren linken "Export"-Button.</td>
             </tr>
             <tr>
               <td><code>plugin/zoom/zoomLevel</code></td>

--- a/packages/clients/diplan/example/polar-ui/setup.js
+++ b/packages/clients/diplan/example/polar-ui/setup.js
@@ -54,7 +54,6 @@ export default (client, layerConf, config) => {
       const actionToast = document.getElementById('action-toast')
       const actionLoadGeoJson = document.getElementById('action-load-geojson')
       const actionZoomToAll = document.getElementById('action-zoom-to-all')
-      const actionScreenshot = document.getElementById('action-screenshot')
       const actionFillAddressSearch = document.getElementById(
         'action-address-search-filler'
       )

--- a/packages/clients/diplan/example/polar-ui/setup.js
+++ b/packages/clients/diplan/example/polar-ui/setup.js
@@ -85,8 +85,6 @@ export default (client, layerConf, config) => {
         mapInstance.$store.dispatch('plugin/draw/zoomToAllFeatures', {
           margin: 10, // defaults to 20
         })
-      actionScreenshot.onclick = () =>
-        mapInstance.$store.dispatch('plugin/export/exportAs', 'Png')
       actionFillAddressSearch.addEventListener('input', (e) =>
         mapInstance.$store.dispatch('plugin/addressSearch/search', {
           input: e.target.value,

--- a/packages/clients/diplan/src/index.html
+++ b/packages/clients/diplan/src/index.html
@@ -107,21 +107,6 @@
               <td id="subscribed-draw">uninitialized</td>
               <td>Die hergestellte Zeichnung als GeoJSON (ohne diplanspezifische Metainformationen und Modifikationen).</td>
             </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-a">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
-            </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-b">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
-            </tr>
-            <tr>
-              <td><code>plugin/...</code></td>
-              <td id="subscribed-c">uninitialized</td>
-              <td>Platz für weitere Beispiele</td>
-            </tr>
           </tbody>
         </table>
       </section>

--- a/packages/clients/diplan/src/setup.js
+++ b/packages/clients/diplan/src/setup.js
@@ -118,6 +118,8 @@ export default (client, layerConf, config) => {
       const htmlRevisedDrawExport = document.getElementById(
         'subscribed-revised-draw-export'
       )
+      const htmlExportA = document.getElementById('subscribed-export-a')
+      const htmlExportImg = document.getElementById('subscribed-export-img')
       const htmlRevisionInProgress = document.getElementById(
         'subscribed-revision-in-progress'
       )
@@ -158,6 +160,10 @@ export default (client, layerConf, config) => {
           htmlSimpleGeometryValidity.innerHTML = simpleGeometryValidity
         }
       )
+      mapInstance.subscribe('plugin/export/exportedMap', (img) => {
+        htmlExportA.setAttribute('href', img)
+        htmlExportImg.setAttribute('src', img)
+      })
 
       window.mapInstance = mapInstance
     })


### PR DESCRIPTION
## Summary

The examples were inconsistent/dysfunct regarding the screenshot button. This has been smoothened. While at it, placeholder rows have been removed as per Curly's Extended Law. ("Do two things at most.")

## Instructions for local reproduction and review

See dev mode and diplan-ui-one examples. In all others, the feature has been hidden.
