### PR TITLE
refactor store to be initialized initialler

### DIFF
--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -134,9 +134,6 @@ export default Vue.extend({
     },
   },
   mounted() {
-    if (this.mapConfiguration.secureServiceUrlRegex) {
-      this.addInterceptor(this.mapConfiguration.secureServiceUrlRegex)
-    }
     const map = api.map.createMap(
       {
         target: this.$refs['polar-map-container'],
@@ -167,7 +164,6 @@ export default Vue.extend({
       )
     }
     this.updateListeners(this.hasWindowSize)
-    this.setConfiguration(this.mapConfiguration)
     this.mapConfiguration.locales?.forEach?.((locale: Locale) =>
       i18next.addResourceBundle(locale.type, 'common', locale.resources, true)
     )
@@ -189,9 +185,8 @@ export default Vue.extend({
     }
   },
   methods: {
-    ...mapMutations(['setConfiguration', 'setHasSmallDisplay', 'setMap']),
+    ...mapMutations(['setHasSmallDisplay', 'setMap']),
     ...mapActions([
-      'addInterceptor',
       'checkServiceAvailability',
       'updateDragAndZoomInteractions',
       'useExtendedMasterportalapiMarkers',

--- a/packages/core/src/utils/createMap/index.ts
+++ b/packages/core/src/utils/createMap/index.ts
@@ -42,13 +42,9 @@ export default async function createMap({
           mapConfiguration: { ...defaults, ...mapConfiguration },
         },
       }),
-    store: makeStore(),
+    store: makeStore(mapConfiguration),
   })
   instance.subscribe = subscribeFunction
-
-  if (mapConfiguration.oidcToken) {
-    instance.$store.commit('setOidcToken', mapConfiguration.oidcToken)
-  }
 
   pullPolarStyleToShadow(shadowRoot, mapConfiguration.stylePath)
   pullVuetifyStyleToShadow(shadowRoot)

--- a/packages/core/src/vuePlugins/vuex.ts
+++ b/packages/core/src/vuePlugins/vuex.ts
@@ -11,6 +11,7 @@ import noop from '@repositoryname/noop'
 import i18next from 'i18next'
 import {
   CoreState,
+  MapConfig,
   MoveHandleActionButton,
   MoveHandleProperties,
   PluginContainer,
@@ -83,7 +84,7 @@ const getInitialState = (): CoreState => ({
 
 // OK for store creation
 // eslint-disable-next-line max-lines-per-function
-export const makeStore = () => {
+export const makeStore = (mapConfiguration: MapConfig) => {
   /*
    * NOTE: The following variables are used to store complex information
    * retrievable from the store without actually adding them to the store.
@@ -281,5 +282,15 @@ export const makeStore = () => {
   i18next.on('languageChanged', (language) => {
     store.commit('setLanguage', language)
   })
+
+  store.commit('setConfiguration', mapConfiguration)
+  if (mapConfiguration.oidcToken) {
+    // copied to a separate spot for usage as it's changable data at run-time
+    store.commit('setOidcToken', mapConfiguration.oidcToken)
+  }
+  if (mapConfiguration.secureServiceUrlRegex) {
+    store.dispatch('addInterceptor', mapConfiguration.secureServiceUrlRegex)
+  }
+
   return store
 }


### PR DESCRIPTION
## Summary

The initial initialization has become even more initial! Now with setting up data during data setup.

## Instructions for local reproduction and review

Please review whether I missed a thing.

* `mapConfiguration`, `oidcToken`, and `secureServiceUrlRegex` are now treated at time of store initialization.
* All other initialization has been postponed until after the map actually exists, e.g. due to requiring the Toast addon in error case.
