### PR TITLE
Dish client: Feature/adjust scale values

### DIFF
--- a/packages/clients/dish/src/mapConfigurations/mapConfig.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfig.ts
@@ -7,6 +7,24 @@ import { mapConfigExtern } from './mapConfigExtern'
 
 let zoomLevel = 0
 
+export const options = [
+  { resolution: 264.583190458, scale: 1000000, zoomLevel: zoomLevel++ },
+  { resolution: 132.291595229, scale: 500000, zoomLevel: zoomLevel++ },
+  { resolution: 66.14579761460263, scale: 250000, zoomLevel: zoomLevel++ },
+  { resolution: 26.458319045841044, scale: 100000, zoomLevel: zoomLevel++ },
+  { resolution: 15.874991427504629, scale: 60000, zoomLevel: zoomLevel++ },
+  { resolution: 10.583327618336419, scale: 40000, zoomLevel: zoomLevel++ },
+  { resolution: 5.2916638091682096, scale: 20000, zoomLevel: zoomLevel++ },
+  { resolution: 2.6458319045841048, scale: 10000, zoomLevel: zoomLevel++ },
+  { resolution: 1.3229159522920524, scale: 5000, zoomLevel: zoomLevel++ },
+  { resolution: 0.6614579761460262, scale: 2500, zoomLevel: zoomLevel++ },
+  { resolution: 0.2645831904584105, scale: 1000, zoomLevel: zoomLevel++ },
+  { resolution: 0.1322915952292052, scale: 500, zoomLevel: zoomLevel++ },
+  { resolution: 0.06614579761, scale: 250, zoomLevel: zoomLevel++ },
+  { resolution: 0.02645831904, scale: 100, zoomLevel: zoomLevel++ },
+  { resolution: 0.01322915952, scale: 50, zoomLevel: zoomLevel++ },
+]
+
 const commonMapConfiguration: Partial<MapConfig> = {
   startResolution: 264.583190458,
   startCenter: [553655.72, 6004479.25],
@@ -24,23 +42,7 @@ const commonMapConfiguration: Partial<MapConfig> = {
       },
     },
   },
-  options: [
-    { resolution: 264.583190458, scale: 1000000, zoomLevel: zoomLevel++ },
-    { resolution: 132.291595229, scale: 500000, zoomLevel: zoomLevel++ },
-    { resolution: 66.14579761460263, scale: 250000, zoomLevel: zoomLevel++ },
-    { resolution: 26.458319045841044, scale: 100000, zoomLevel: zoomLevel++ },
-    { resolution: 15.874991427504629, scale: 60000, zoomLevel: zoomLevel++ },
-    { resolution: 10.583327618336419, scale: 40000, zoomLevel: zoomLevel++ },
-    { resolution: 5.2916638091682096, scale: 20000, zoomLevel: zoomLevel++ },
-    { resolution: 2.6458319045841048, scale: 10000, zoomLevel: zoomLevel++ },
-    { resolution: 1.3229159522920524, scale: 5000, zoomLevel: zoomLevel++ },
-    { resolution: 0.6614579761460262, scale: 2500, zoomLevel: zoomLevel++ },
-    { resolution: 0.2645831904584105, scale: 1000, zoomLevel: zoomLevel++ },
-    { resolution: 0.1322915952292052, scale: 500, zoomLevel: zoomLevel++ },
-    { resolution: 0.06614579761, scale: 250, zoomLevel: zoomLevel++ },
-    { resolution: 0.02645831904, scale: 100, zoomLevel: zoomLevel++ },
-    { resolution: 0.01322915952, scale: 50, zoomLevel: zoomLevel++ },
-  ],
+  options,
 }
 
 export const getMapConfiguration = (

--- a/packages/clients/dish/src/mapConfigurations/mapConfig.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfig.ts
@@ -2,28 +2,9 @@ import { MapConfig } from '@polar/lib-custom-types'
 import locales from '../locales'
 import { shBlue, shWhite } from '../colors'
 import { DishMapConfig, DishUrlParams } from '../types'
+import { options } from '../utils/calculateScaleFromResolution'
 import { mapConfigIntern } from './mapConfigIntern'
 import { mapConfigExtern } from './mapConfigExtern'
-
-let zoomLevel = 0
-
-export const options = [
-  { resolution: 264.583190458, scale: 1000000, zoomLevel: zoomLevel++ },
-  { resolution: 132.291595229, scale: 500000, zoomLevel: zoomLevel++ },
-  { resolution: 66.14579761460263, scale: 250000, zoomLevel: zoomLevel++ },
-  { resolution: 26.458319045841044, scale: 100000, zoomLevel: zoomLevel++ },
-  { resolution: 15.874991427504629, scale: 60000, zoomLevel: zoomLevel++ },
-  { resolution: 10.583327618336419, scale: 40000, zoomLevel: zoomLevel++ },
-  { resolution: 5.2916638091682096, scale: 20000, zoomLevel: zoomLevel++ },
-  { resolution: 2.6458319045841048, scale: 10000, zoomLevel: zoomLevel++ },
-  { resolution: 1.3229159522920524, scale: 5000, zoomLevel: zoomLevel++ },
-  { resolution: 0.6614579761460262, scale: 2500, zoomLevel: zoomLevel++ },
-  { resolution: 0.2645831904584105, scale: 1000, zoomLevel: zoomLevel++ },
-  { resolution: 0.1322915952292052, scale: 500, zoomLevel: zoomLevel++ },
-  { resolution: 0.06614579761, scale: 250, zoomLevel: zoomLevel++ },
-  { resolution: 0.02645831904, scale: 100, zoomLevel: zoomLevel++ },
-  { resolution: 0.01322915952, scale: 50, zoomLevel: zoomLevel++ },
-]
 
 const commonMapConfiguration: Partial<MapConfig> = {
   startResolution: 264.583190458,

--- a/packages/clients/dish/src/mapConfigurations/mapConfigExtern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigExtern.ts
@@ -13,6 +13,7 @@ import {
   denkmaelerWFS,
 } from '../servicesConstants'
 import { DishMapConfig } from '../types'
+import { calculateScaleFromResolution } from '../utils/calculateScaleFromResolution'
 import {
   attributionsBasemapGrau,
   attributionsAlkisWms,
@@ -91,7 +92,10 @@ export const mapConfigExtern: DishMapConfig = {
       id: alkisWms,
       visibility: true,
       type: 'mask',
-      name: 'ALKIS Flurstücke (ab 1:1.000)',
+      name: `ALKIS Flurstücke (ab 1:${calculateScaleFromResolution(
+        'm',
+        0.2645831904584105
+      )})`,
       minZoom: 10,
     },
   ],

--- a/packages/clients/dish/src/mapConfigurations/mapConfigExtern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigExtern.ts
@@ -13,7 +13,7 @@ import {
   denkmaelerWFS,
 } from '../servicesConstants'
 import { DishMapConfig } from '../types'
-import { calculateScaleFromResolution } from '../utils/calculateScaleFromResolution'
+import { scaleFromZoomLevel } from '../utils/calculateScaleFromResolution'
 import {
   attributionsBasemapGrau,
   attributionsAlkisWms,
@@ -25,6 +25,8 @@ import {
   categoryProps,
   groupProperties,
 } from './searchConfigParams'
+
+const alkisMinZoom = 10
 
 export const mapConfigExtern: DishMapConfig = {
   checkServiceAvailability: false,
@@ -92,11 +94,8 @@ export const mapConfigExtern: DishMapConfig = {
       id: alkisWms,
       visibility: true,
       type: 'mask',
-      name: `ALKIS Flurstücke (ab 1:${calculateScaleFromResolution(
-        'm',
-        0.2645831904584105
-      )})`,
-      minZoom: 10,
+      name: `ALKIS Flurstücke (ab 1:${scaleFromZoomLevel(alkisMinZoom)})`,
+      minZoom: alkisMinZoom,
     },
   ],
   attributions: {

--- a/packages/clients/dish/src/plugins/DishExportMap/DishExportMap.vue
+++ b/packages/clients/dish/src/plugins/DishExportMap/DishExportMap.vue
@@ -150,7 +150,6 @@ export default Vue.extend({
       this.dialog = true
     },
     setTitle() {
-      console.warn(beautifyScale(this.scaleValue))
       if (this.overlay && this.hasObjectProperties) {
         const objectId = this.currentProperties.objektid
         const address = [

--- a/packages/clients/dish/src/plugins/DishExportMap/DishExportMap.vue
+++ b/packages/clients/dish/src/plugins/DishExportMap/DishExportMap.vue
@@ -57,6 +57,7 @@
 import Vue from 'vue'
 import { mapMutations, mapGetters } from 'vuex'
 import Overlay from 'ol/Overlay'
+import { beautifyScale } from '@polar/plugin-scale'
 import { denkmaelerWMS, denkmaelerWFS } from '../../servicesConstants'
 
 const rectangleWidth = 893
@@ -149,6 +150,7 @@ export default Vue.extend({
       this.dialog = true
     },
     setTitle() {
+      console.warn(beautifyScale(this.scaleValue))
       if (this.overlay && this.hasObjectProperties) {
         const objectId = this.currentProperties.objektid
         const address = [
@@ -195,7 +197,7 @@ export default Vue.extend({
         NewTab: true,
         objektueberschrift: this.title,
         // spelling is intentional because of backend requirements
-        masssstab: this.scaleValue,
+        masssstab: beautifyScale(this.scaleValue),
         printApproach: this.configuration.dishExportMap.printApproach,
         printRequester: this.configuration.dishExportMap.printRequester,
         id: this.currentProperties.objektid,

--- a/packages/clients/dish/src/utils/calculateScaleFromResolution.ts
+++ b/packages/clients/dish/src/utils/calculateScaleFromResolution.ts
@@ -1,0 +1,13 @@
+import { beautifyScale, getDpi, thousandsSeparator } from '@polar/plugin-scale'
+import * as olProj from 'ol/proj'
+
+export function calculateScaleFromResolution(
+  unit: string,
+  resolution: number
+): string {
+  const inchesPerMetre = 39.37
+  const scale = Math.round(
+    resolution * olProj.METERS_PER_UNIT[unit] * inchesPerMetre * getDpi()
+  )
+  return thousandsSeparator(beautifyScale(scale))
+}

--- a/packages/clients/dish/src/utils/calculateScaleFromResolution.ts
+++ b/packages/clients/dish/src/utils/calculateScaleFromResolution.ts
@@ -1,6 +1,25 @@
 import { beautifyScale, getDpi, thousandsSeparator } from '@polar/plugin-scale'
 import * as olProj from 'ol/proj'
-import { options } from '../mapConfigurations/mapConfig'
+
+let zoomLevel = 0
+
+export const options = [
+  { resolution: 264.583190458, scale: 1000000, zoomLevel: zoomLevel++ },
+  { resolution: 132.291595229, scale: 500000, zoomLevel: zoomLevel++ },
+  { resolution: 66.14579761460263, scale: 250000, zoomLevel: zoomLevel++ },
+  { resolution: 26.458319045841044, scale: 100000, zoomLevel: zoomLevel++ },
+  { resolution: 15.874991427504629, scale: 60000, zoomLevel: zoomLevel++ },
+  { resolution: 10.583327618336419, scale: 40000, zoomLevel: zoomLevel++ },
+  { resolution: 5.2916638091682096, scale: 20000, zoomLevel: zoomLevel++ },
+  { resolution: 2.6458319045841048, scale: 10000, zoomLevel: zoomLevel++ },
+  { resolution: 1.3229159522920524, scale: 5000, zoomLevel: zoomLevel++ },
+  { resolution: 0.6614579761460262, scale: 2500, zoomLevel: zoomLevel++ },
+  { resolution: 0.2645831904584105, scale: 1000, zoomLevel: zoomLevel++ },
+  { resolution: 0.1322915952292052, scale: 500, zoomLevel: zoomLevel++ },
+  { resolution: 0.06614579761, scale: 250, zoomLevel: zoomLevel++ },
+  { resolution: 0.02645831904, scale: 100, zoomLevel: zoomLevel++ },
+  { resolution: 0.01322915952, scale: 50, zoomLevel: zoomLevel++ },
+]
 
 function calculateScaleFromResolution(
   unit: string,

--- a/packages/clients/dish/src/utils/calculateScaleFromResolution.ts
+++ b/packages/clients/dish/src/utils/calculateScaleFromResolution.ts
@@ -1,7 +1,8 @@
 import { beautifyScale, getDpi, thousandsSeparator } from '@polar/plugin-scale'
 import * as olProj from 'ol/proj'
+import { options } from '../mapConfigurations/mapConfig'
 
-export function calculateScaleFromResolution(
+function calculateScaleFromResolution(
   unit: string,
   resolution: number
 ): string {
@@ -11,3 +12,6 @@ export function calculateScaleFromResolution(
   )
   return thousandsSeparator(beautifyScale(scale))
 }
+
+export const scaleFromZoomLevel = (zoomLevel: number) =>
+  calculateScaleFromResolution('m', options[zoomLevel].resolution)

--- a/packages/plugins/Scale/CHANGELOG.md
+++ b/packages/plugins/Scale/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Feature: Expose the `beautifyScale` function.
+
 ## 3.0.0
 
 - Breaking: Upgrade peerDependency `ol` from `^9.2.4` to `^10.3.1`.

--- a/packages/plugins/Scale/CHANGELOG.md
+++ b/packages/plugins/Scale/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unpublished
 
-- Feature: Expose the `beautifyScale` function.
+- Feature: Expose the functions `beautifyScale`, `thousandsSeparator` and `getDpi`.
 
 ## 3.0.0
 

--- a/packages/plugins/Scale/src/index.ts
+++ b/packages/plugins/Scale/src/index.ts
@@ -4,6 +4,8 @@ import { Scale } from './components'
 import locales from './locales'
 import { makeStoreModule } from './store'
 
+export { default as beautifyScale } from './utils/beautifyScale'
+
 export default (options: ScaleConfiguration) => (instance: Vue) =>
   instance.$store.dispatch('addComponent', {
     name: 'scale',

--- a/packages/plugins/Scale/src/index.ts
+++ b/packages/plugins/Scale/src/index.ts
@@ -5,6 +5,8 @@ import locales from './locales'
 import { makeStoreModule } from './store'
 
 export { default as beautifyScale } from './utils/beautifyScale'
+export { default as thousandsSeparator } from './utils/thousandsSeperator'
+export { default as getDpi } from './utils/getDpi'
 
 export default (options: ScaleConfiguration) => (instance: Vue) =>
   instance.$store.dispatch('addComponent', {


### PR DESCRIPTION
## Summary

The scale description in the layer chooser for the alkis layer is now calculated to show the right scale depending on different devices.

## Instructions for local reproduction and review

- set the mode to `EXTERN`
- start the dish client
- check the scale value in the layer chooser for alkis layer
- you can change the returned dpi in the function `getDpi` of the scale plugin to get different results.

## Pull Request Checklist (for Assignee)

- [ ] Changelogs are maintained
- [ ] Functionality has been tested in Firefox, Chrome, Safari
- [ ] Functionality has been tested on a smartphone
- [ ] Functionality has been tested with 200% screen zoom
- [ ] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [ ] Chrome Lighthouse
  - [ ] Firefox Accessibility

## Relevant tickets, issues, et cetera
