### PR TITLE
Fix/disabled masks

### DIFF
--- a/packages/clients/diplan/example/diplan-ui-one/config.js
+++ b/packages/clients/diplan/example/diplan-ui-one/config.js
@@ -152,8 +152,7 @@ export default {
     {
       id: flurstuecke,
       visibility: false,
-      // TODO: Re-add once the ui has been fixed for this
-      // minZoom: 7,
+      minZoom: 7,
       type: 'mask',
       name: `diplan.layers.${flurstuecke}`,
     },

--- a/packages/clients/diplan/example/diplan-ui-two/config.js
+++ b/packages/clients/diplan/example/diplan-ui-two/config.js
@@ -153,8 +153,7 @@ export default {
     {
       id: flurstuecke,
       visibility: false,
-      // TODO: Re-add once the ui has been fixed for this
-      // minZoom: 7,
+      minZoom: 7,
       type: 'mask',
       name: `diplan.layers.${flurstuecke}`,
     },

--- a/packages/clients/diplan/src/config.js
+++ b/packages/clients/diplan/src/config.js
@@ -149,8 +149,7 @@ export default {
     {
       id: flurstuecke,
       visibility: false,
-      // TODO: Re-add once the ui has been fixed for this
-      // minZoom: 7,
+      minZoom: 7,
       type: 'mask',
       name: `diplan.layers.${flurstuecke}`,
     },

--- a/packages/clients/diplan/src/plugins/IconMenu/IconMenuButton.vue
+++ b/packages/clients/diplan/src/plugins/IconMenu/IconMenuButton.vue
@@ -7,7 +7,7 @@
         height="40"
         :aria-label="$t(hint ? hint : `plugins.iconMenu.hints.${id}`)"
         v-bind="attrs"
-        @click="toggle(Number(index))"
+        @click="toggle(index)"
         v-on="on"
       >
         <v-icon :color="open === index ? 'primaryContrast' : 'primary'">

--- a/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
+++ b/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
@@ -11,7 +11,7 @@
             <template v-for="({ name, id }, index) in backgrounds">
               <LayerWrapper
                 :key="'disabled-background-' + index"
-                :index="index"
+                :index="Number(index)"
                 :disabled-layers="disabledBackgrounds"
                 :layer-id="id"
               >
@@ -56,7 +56,7 @@
                     dense
                     hide-details
                     class="cut-off-top-space"
-                    :disabled="disabledMasks[index]"
+                    :disabled="disabledMasks[id]"
                   />
                 </LayerWrapper>
                 <v-divider :key="index" />

--- a/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
+++ b/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
@@ -8,24 +8,22 @@
         <v-divider />
         <v-expansion-panel-content>
           <v-radio-group v-model="activeBackground" dense hide-details>
-            <template v-for="({ name, id }, index) in backgrounds">
+            <template v-for="{ name, id } in backgrounds">
               <LayerWrapper
-                :key="'disabled-background-' + index"
-                :index="index"
+                :key="`background-layer-${id}`"
                 :disabled-layers="disabledBackgrounds"
                 :layer-id="id"
               >
                 <v-radio
-                  :key="index"
                   aria-describedby="polar-label-background-title"
                   dense
                   hide-details
                   :label="$t(name)"
                   :value="id"
-                  :disabled="disabledBackgrounds[index]"
+                  :disabled="disabledBackgrounds[id]"
                 />
               </LayerWrapper>
-              <v-divider :key="index" />
+              <v-divider :key="`background-divider-${id}`" />
             </template>
           </v-radio-group>
         </v-expansion-panel-content>
@@ -41,10 +39,9 @@
           <v-divider />
           <v-expansion-panel-content>
             <template v-if="displaySelection">
-              <template v-for="({ name, id }, index) in masks">
+              <template v-for="{ name, id } in masks">
                 <LayerWrapper
-                  :key="`disabled-mask-${type}-${index}`"
-                  :index="index"
+                  :key="`mask-layer-${type}-${id}`"
                   :disabled-layers="disabledMasks"
                   :layer-id="id"
                 >
@@ -59,7 +56,7 @@
                     :disabled="disabledMasks[id]"
                   />
                 </LayerWrapper>
-                <v-divider :key="index" />
+                <v-divider :key="`mask-divider-${id}`" />
               </template>
             </template>
             <LayerChooserOptions v-else />

--- a/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
+++ b/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
@@ -11,7 +11,7 @@
             <template v-for="({ name, id }, index) in backgrounds">
               <LayerWrapper
                 :key="'disabled-background-' + index"
-                :index="Number(index)"
+                :index="index"
                 :disabled-layers="disabledBackgrounds"
                 :layer-id="id"
               >
@@ -44,7 +44,7 @@
               <template v-for="({ name, id }, index) in masks">
                 <LayerWrapper
                   :key="`disabled-mask-${type}-${index}`"
-                  :index="Number(index)"
+                  :index="index"
                   :disabled-layers="disabledMasks"
                   :layer-id="id"
                 >

--- a/packages/clients/diplan/src/plugins/LayerChooser/LayerWrapper.vue
+++ b/packages/clients/diplan/src/plugins/LayerChooser/LayerWrapper.vue
@@ -27,8 +27,8 @@ export default Vue.extend({
       required: true,
     },
     disabledLayers: {
-      type: Array,
-      default: () => [],
+      type: [Array, Object],
+      required: true,
     },
     layerId: {
       type: String,

--- a/packages/clients/diplan/src/plugins/LayerChooser/LayerWrapper.vue
+++ b/packages/clients/diplan/src/plugins/LayerChooser/LayerWrapper.vue
@@ -1,6 +1,5 @@
 <template>
   <LayerChooserLayerWrapper
-    :index="index"
     :disabled-layers="disabledLayers"
     :layer-id="layerId"
     icon="$vuetify.icons.gear-outline"
@@ -10,8 +9,11 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
-import { LayerChooserLayerWrapper } from '@polar/plugin-layer-chooser'
+import Vue, { PropType } from 'vue'
+import {
+  DisabledLayers,
+  LayerChooserLayerWrapper,
+} from '@polar/plugin-layer-chooser'
 
 /**
  * Adds tooltip and option action to arbitrary selection element.
@@ -22,12 +24,8 @@ export default Vue.extend({
     LayerChooserLayerWrapper,
   },
   props: {
-    index: {
-      type: Number,
-      required: true,
-    },
     disabledLayers: {
-      type: [Array, Object],
+      type: Object as PropType<DisabledLayers>,
       required: true,
     },
     layerId: {

--- a/packages/plugins/IconMenu/src/components/IconMenu.vue
+++ b/packages/plugins/IconMenu/src/components/IconMenu.vue
@@ -18,14 +18,14 @@
           :id="id"
           :icon="icon"
           :hint="hint"
-          :index="Number(index)"
+          :index="index"
         />
         <IconMenuButton
           v-else
           :id="id"
           :icon="icon"
           :hint="hint"
-          :index="Number(index)"
+          :index="index"
         />
         <!-- Content displayed in MoveHandle of the core if has-window-size and has-small-width are true -->
         <component

--- a/packages/plugins/IconMenu/src/components/IconMenuButton.vue
+++ b/packages/plugins/IconMenu/src/components/IconMenuButton.vue
@@ -7,7 +7,7 @@
         small
         :aria-label="$t(hint ? hint : `plugins.iconMenu.hints.${id}`)"
         v-bind="attrs"
-        @click="toggle(Number(index))"
+        @click="toggle(index)"
         v-on="on"
       >
         <v-icon :color="open === index ? 'primary' : 'primaryContrast'">

--- a/packages/plugins/LayerChooser/CHANGELOG.md
+++ b/packages/plugins/LayerChooser/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unpublished
 
 - Feature: Change configuration of `layer.type` to be set to `background` or any other String. All layers that have their `type` not set to `background` are considered "overlays". For the type `mask` locales are already implemented. For any additional type, these have to be added separately.
+- Feature: Add new exported type `DisabledLayers` describing an object structure mapping layerIds to whether the respective layer is disabled or not.
 - Fix: Layer options layer names are now translated if they're locale keys.
 
 ## 2.1.0

--- a/packages/plugins/LayerChooser/src/components/LayerWrapper.vue
+++ b/packages/plugins/LayerChooser/src/components/LayerWrapper.vue
@@ -20,8 +20,9 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue'
+import Vue, { PropType } from 'vue'
 import { mapGetters, mapMutations } from 'vuex'
+import { DisabledLayers } from '../types'
 
 /**
  * Adds tooltip and option action to arbitrary selection element.
@@ -29,12 +30,8 @@ import { mapGetters, mapMutations } from 'vuex'
 export default Vue.extend({
   name: 'LayerChooserLayerWrapper',
   props: {
-    index: {
-      type: Number,
-      required: true,
-    },
     disabledLayers: {
-      type: [Array, Object],
+      type: Object as PropType<DisabledLayers>,
       required: true,
     },
     layerId: {
@@ -53,9 +50,7 @@ export default Vue.extend({
       return this.idsWithOptions.includes(this.layerId)
     },
     disabled() {
-      return Array.isArray(this.disabledLayers)
-        ? this.disabledLayers[this.index]
-        : this.disabledLayers[this.layerId]
+      return this.disabledLayers[this.layerId]
     },
   },
   methods: {

--- a/packages/plugins/LayerChooser/src/components/LayerWrapper.vue
+++ b/packages/plugins/LayerChooser/src/components/LayerWrapper.vue
@@ -1,10 +1,7 @@
 <template>
   <v-tooltip left :disabled="hasSmallDisplay">
     <template #activator="{ on }">
-      <div
-        class="polar-layer-chooser-option-line"
-        v-on="disabledLayers[index] && on"
-      >
+      <div class="polar-layer-chooser-option-line" v-on="disabled && on">
         <slot></slot>
         <v-btn
           class="ml-1"
@@ -37,7 +34,7 @@ export default Vue.extend({
       required: true,
     },
     disabledLayers: {
-      type: Array,
+      type: [Array, Object],
       required: true,
     },
     layerId: {
@@ -54,6 +51,11 @@ export default Vue.extend({
     ...mapGetters('plugin/layerChooser', ['idsWithOptions']),
     hasOptions() {
       return this.idsWithOptions.includes(this.layerId)
+    },
+    disabled() {
+      return Array.isArray(this.disabledLayers)
+        ? this.disabledLayers[this.index]
+        : this.disabledLayers[this.layerId]
     },
   },
   methods: {

--- a/packages/plugins/LayerChooser/src/components/Selection.vue
+++ b/packages/plugins/LayerChooser/src/components/Selection.vue
@@ -6,21 +6,19 @@
       }}</v-card-title>
       <v-card-text>
         <v-radio-group v-model="activeBackground" dense hide-details>
-          <template v-for="({ name, id }, index) in backgrounds">
+          <template v-for="{ name, id } in backgrounds">
             <LayerWrapper
-              :key="'disabled-background-' + index"
-              :index="index"
+              :key="`background-layer-${id}`"
               :disabled-layers="disabledBackgrounds"
               :layer-id="id"
             >
               <v-radio
-                :key="index"
                 aria-describedby="polar-label-background-title"
                 dense
                 hide-details
                 :label="$t(name)"
                 :value="id"
-                :disabled="disabledBackgrounds[index]"
+                :disabled="disabledBackgrounds[id]"
                 @keydown.up.stop
                 @keydown.right.stop
                 @keydown.down.stop
@@ -40,10 +38,9 @@
           {{ $t(`plugins.layerChooser.${type}Title`) }}
         </v-card-title>
         <v-card-text :key="`layer-chooser-mask-text-${type}`">
-          <template v-for="({ name, id }, index) in masks">
+          <template v-for="{ name, id } in masks">
             <LayerWrapper
-              :key="`disabled-mask-${type}-${index}`"
-              :index="index"
+              :key="`mask-layer-${type}-${id}`"
               :disabled-layers="disabledMasks"
               :layer-id="id"
             >

--- a/packages/plugins/LayerChooser/src/components/Selection.vue
+++ b/packages/plugins/LayerChooser/src/components/Selection.vue
@@ -9,7 +9,7 @@
           <template v-for="({ name, id }, index) in backgrounds">
             <LayerWrapper
               :key="'disabled-background-' + index"
-              :index="Number(index)"
+              :index="index"
               :disabled-layers="disabledBackgrounds"
               :layer-id="id"
             >
@@ -43,7 +43,7 @@
           <template v-for="({ name, id }, index) in masks">
             <LayerWrapper
               :key="`disabled-mask-${type}-${index}`"
-              :index="Number(index)"
+              :index="index"
               :disabled-layers="disabledMasks"
               :layer-id="id"
             >

--- a/packages/plugins/LayerChooser/src/components/Selection.vue
+++ b/packages/plugins/LayerChooser/src/components/Selection.vue
@@ -55,7 +55,7 @@
                 dense
                 hide-details
                 class="cut-off-top-space"
-                :disabled="disabledMasks[index]"
+                :disabled="disabledMasks[id]"
               />
             </LayerWrapper>
           </template>

--- a/packages/plugins/LayerChooser/src/index.ts
+++ b/packages/plugins/LayerChooser/src/index.ts
@@ -4,9 +4,11 @@ import { LayerChooser } from './components'
 import locales from './locales'
 import { makeStoreModule } from './store'
 
+import { type DisabledLayers } from './types'
 import LayerChooserLayerWrapper from './components/LayerWrapper.vue'
 import LayerChooserOptions from './components/Options.vue'
-export { LayerChooserLayerWrapper, LayerChooserOptions }
+
+export { type DisabledLayers, LayerChooserLayerWrapper, LayerChooserOptions }
 
 export default (options: LayerChooserConfiguration) => (instance: Vue) =>
   instance.$store.dispatch('addComponent', {

--- a/packages/plugins/LayerChooser/src/store/index.ts
+++ b/packages/plugins/LayerChooser/src/store/index.ts
@@ -208,10 +208,15 @@ export const makeStoreModule = () => {
       disabledMasks(_, { availableMasks, masks }) {
         return masks
           .filter(({ hideInMenu }) => !hideInMenu)
-          .map(({ id }) =>
-            availableMasks.findIndex((available) => available.id === id)
+          .reduce(
+            (acc, { id }) => ({
+              ...acc,
+              [id]:
+                availableMasks.findIndex((available) => available.id === id) ===
+                -1,
+            }),
+            {}
           )
-          .map((index) => index === -1)
       },
       idsWithOptions(_, { backgrounds, masks }) {
         return [...backgrounds, ...masks]

--- a/packages/plugins/LayerChooser/src/store/index.ts
+++ b/packages/plugins/LayerChooser/src/store/index.ts
@@ -13,6 +13,7 @@ import { LayerChooserGetters, LayerChooserState } from '../types'
 import { asIdList, areLayersActive } from '../utils/layerFolding'
 import { getBackgroundsAndMasks } from '../utils/getBackgroundsAndMasks'
 import { getOpenedOptionsServiceLayers } from '../utils/getOpenedOptionsServiceLayers'
+import { isLayerIdIncluded } from '../utils/isLayerIdIncluded'
 
 export const getInitialState = (): LayerChooserState => ({
   openedOptions: null,
@@ -199,11 +200,13 @@ export const makeStoreModule = () => {
           ? rootGetters.configuration.layerChooser.component
           : null,
       disabledBackgrounds(_, { availableBackgrounds, backgrounds }) {
-        return backgrounds
-          .map(({ id }) =>
-            availableBackgrounds.findIndex((available) => available.id === id)
-          )
-          .map((index) => index === -1)
+        return backgrounds.reduce(
+          (acc, { id }) => ({
+            ...acc,
+            [id]: isLayerIdIncluded(availableBackgrounds, id) === -1,
+          }),
+          {}
+        )
       },
       disabledMasks(_, { availableMasks, masks }) {
         return masks
@@ -211,9 +214,7 @@ export const makeStoreModule = () => {
           .reduce(
             (acc, { id }) => ({
               ...acc,
-              [id]:
-                availableMasks.findIndex((available) => available.id === id) ===
-                -1,
+              [id]: isLayerIdIncluded(availableMasks, id) === -1,
             }),
             {}
           )

--- a/packages/plugins/LayerChooser/src/store/index.ts
+++ b/packages/plugins/LayerChooser/src/store/index.ts
@@ -201,7 +201,7 @@ export const makeStoreModule = () => {
         return backgrounds.reduce(
           (acc, { id }) => ({
             ...acc,
-            [id]: isLayerIdIncluded(availableBackgrounds, id) === -1,
+            [id]: isLayerIdIncluded(availableBackgrounds, id),
           }),
           {}
         )
@@ -212,7 +212,7 @@ export const makeStoreModule = () => {
           .reduce(
             (acc, { id }) => ({
               ...acc,
-              [id]: isLayerIdIncluded(availableMasks, id) === -1,
+              [id]: isLayerIdIncluded(availableMasks, id),
             }),
             {}
           )

--- a/packages/plugins/LayerChooser/src/types.ts
+++ b/packages/plugins/LayerChooser/src/types.ts
@@ -3,6 +3,8 @@ import { VueConstructor } from 'vue'
 
 export type IdManipulator = (ids: (string | number)[]) => (number | string)[]
 
+export type DisabledLayers = Record<string, boolean>
+
 export interface LayerChooserState {
   /** null indicates no options are open; string is layer ID of opened opts */
   openedOptions: null | string
@@ -19,8 +21,8 @@ export interface LayerChooserState {
 
 export interface LayerChooserGetters extends LayerChooserState {
   component: VueConstructor | null
-  disabledBackgrounds: boolean[]
-  disabledMasks: Record<string, boolean>
+  disabledBackgrounds: DisabledLayers
+  disabledMasks: DisabledLayers
   idsWithOptions: string[]
   masksSeparatedByType: Record<string, LayerConfiguration[]>
   openedOptionsService: LayerConfiguration

--- a/packages/plugins/LayerChooser/src/types.ts
+++ b/packages/plugins/LayerChooser/src/types.ts
@@ -20,7 +20,7 @@ export interface LayerChooserState {
 export interface LayerChooserGetters extends LayerChooserState {
   component: VueConstructor | null
   disabledBackgrounds: boolean[]
-  disabledMasks: boolean[]
+  disabledMasks: Record<string, boolean>
   idsWithOptions: string[]
   masksSeparatedByType: Record<string, LayerConfiguration[]>
   openedOptionsService: LayerConfiguration

--- a/packages/plugins/LayerChooser/src/utils/isLayerIdIncluded.ts
+++ b/packages/plugins/LayerChooser/src/utils/isLayerIdIncluded.ts
@@ -1,0 +1,4 @@
+import { LayerConfiguration } from '@polar/lib-custom-types'
+
+export const isLayerIdIncluded = (layers: LayerConfiguration[], id: string) =>
+  layers.findIndex((available) => available.id === id)

--- a/packages/plugins/LayerChooser/src/utils/isLayerIdIncluded.ts
+++ b/packages/plugins/LayerChooser/src/utils/isLayerIdIncluded.ts
@@ -1,4 +1,4 @@
 import { LayerConfiguration } from '@polar/lib-custom-types'
 
 export const isLayerIdIncluded = (layers: LayerConfiguration[], id: string) =>
-  layers.findIndex((available) => available.id === id)
+  layers.findIndex((available) => available.id === id) === -1


### PR DESCRIPTION
## Summary

Wrong layers were disabled when using different types for overlays than `mask` as the getter `disabledMasks` was working on the index.

## Instructions for local reproduction and review

`npm run diplan:dev`

## Pull Request Checklist (for Assignee)

- ~~[ ] Changelogs are maintained~~ Feature has not been published yet
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility
