### PR TITLE
remove lint rules max-line

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,9 +36,7 @@
     "no-eval": "error",
     "no-implied-eval": "error",
     "complexity": "warn",
-    "max-depth": "warn",
-    "max-lines": "error",
-    "max-lines-per-function": "error"
+    "max-depth": "warn"
   },
   "ignorePatterns": ["**/node_modules/**/*", "**/dist/**/*"],
   "settings": {
@@ -57,10 +55,7 @@
       "env": {
         "jest": true
       },
-      "plugins": ["jest"],
-      "rules": {
-        "max-lines-per-function": "off"
-      }
+      "plugins": ["jest"]
     },
     {
       "files": ["packages/**/*.js", "packages/**/*.vue"],

--- a/e2e/draw.spec.ts
+++ b/e2e/draw.spec.ts
@@ -36,8 +36,6 @@ test('the draw tool can be used to draw polygons on the map', async ({
   expect(drawing.features[0].geometry.coordinates[0].length).toBe(7)
 })
 
-// it's fiiine
-// eslint-disable-next-line max-lines-per-function
 test('two features drawn at the same coordinate can be modified separately', async ({
   page,
   isMobile,

--- a/packages/clients/bgw/src/addPlugins.ts
+++ b/packages/clients/bgw/src/addPlugins.ts
@@ -24,7 +24,6 @@ const defaultOptions = {
   layoutTag: NineLayoutTag.TOP_LEFT,
 }
 
-// eslint-disable-next-line max-lines-per-function
 export default (core) => {
   setLayout(NineLayout)
 

--- a/packages/clients/diplan/e2e/draw.spec.ts
+++ b/packages/clients/diplan/e2e/draw.spec.ts
@@ -1,5 +1,3 @@
-// it is what it is – a test file, specifically
-/* eslint-disable max-lines-per-function */
 import { test } from '@playwright/test'
 import { draw } from '../../../../e2e/utils/draw'
 import { openDiPlan } from './utils/openDiplan'

--- a/packages/clients/diplan/example/diplan-ui-one/setup.js
+++ b/packages/clients/diplan/example/diplan-ui-one/setup.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 const geoJSON = {
   type: 'FeatureCollection',
   features: [

--- a/packages/clients/diplan/example/diplan-ui-two/setup.js
+++ b/packages/clients/diplan/example/diplan-ui-two/setup.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 const geoJSON = {
   type: 'FeatureCollection',
   features: [

--- a/packages/clients/diplan/example/polar-ui/setup.js
+++ b/packages/clients/diplan/example/polar-ui/setup.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 const geoJSON = {
   type: 'FeatureCollection',
   features: [

--- a/packages/clients/diplan/example/services.js
+++ b/packages/clients/diplan/example/services.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines */
-
 // TODO reduce to information actually read by masterportalapi
 // TODO move information readable by POLAR to where it belongs in config
 

--- a/packages/clients/diplan/src/addPlugins.ts
+++ b/packages/clients/diplan/src/addPlugins.ts
@@ -22,8 +22,6 @@ import { Zoom } from './plugins/Zoom'
 import GeoEditing from './plugins/GeoEditing'
 import LinkButton from './plugins/LinkButton'
 
-// complexity deemed acceptable for this setup function
-// eslint-disable-next-line max-lines-per-function
 export function addPlugins(core, mode: keyof typeof MODE) {
   setLayout(NineLayout)
 

--- a/packages/clients/diplan/src/setup.js
+++ b/packages/clients/diplan/src/setup.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-lines-per-function */
-
 import { validateForm } from '../example/authentication/validateForm.js'
 
 const geoJSON = {

--- a/packages/clients/diplan/src/store/geoEditing/cutPolygons/index.ts
+++ b/packages/clients/diplan/src/store/geoEditing/cutPolygons/index.ts
@@ -17,8 +17,6 @@ import { makeDraw } from './makeDraw'
 
 const wgs84Epsg = 'EPSG:4326'
 
-// length stems from toast dispatchments
-// eslint-disable-next-line max-lines-per-function
 export const cutPolygons = ({
   dispatch,
   rootGetters,

--- a/packages/clients/diplan/src/store/geoEditing/mergePolygons.ts
+++ b/packages/clients/diplan/src/store/geoEditing/mergePolygons.ts
@@ -12,8 +12,6 @@ import { DiplanGetters, DiplanState } from '../../types'
 
 const converter = new GeoJSON()
 
-// acceptable complexity
-// eslint-disable-next-line max-lines-per-function
 export const mergePolygons = ({
   dispatch,
   rootGetters,

--- a/packages/clients/diplan/src/store/module.ts
+++ b/packages/clients/diplan/src/store/module.ts
@@ -31,8 +31,6 @@ const diplanModule: PolarModule<DiplanState, DiplanGetters> = {
   namespaced: true,
   state: getInitialState(),
   actions: {
-    // setup is long, not deep
-    // eslint-disable-next-line max-lines-per-function
     setupModule({ dispatch, rootGetters }) {
       const debouncedUpdate = debounce(() => dispatch('updateState'), 50)
       this.watch(

--- a/packages/clients/diplan/src/store/updateState/index.ts
+++ b/packages/clients/diplan/src/store/updateState/index.ts
@@ -49,8 +49,6 @@ export const cloneFeatureCollection = (
 ): FeatureCollection<GeometryType> =>
   JSON.parse(JSON.stringify(featureCollection))
 
-// complexity deemed acceptable, it's mostly chaining
-// eslint-disable-next-line max-lines-per-function
 export const updateState = async ({
   commit,
   dispatch,

--- a/packages/clients/dish/src/addPlugins.ts
+++ b/packages/clients/dish/src/addPlugins.ts
@@ -75,8 +75,6 @@ const addressSearchConfig = (mode: keyof typeof MODE) => {
   return addressSearchConfig
 }
 
-// this is fine for list-like setup functions
-// eslint-disable-next-line max-lines-per-function
 export const addPlugins = (core, mode: keyof typeof MODE = 'EXTERN') => {
   const internalMenu = [
     {

--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -1,5 +1,3 @@
-// function includes all plugin configs specifically for internal map use
-/* eslint-disable max-lines-per-function */
 import { SearchMethodConfiguration } from '@polar/lib-custom-types'
 import { alkisWfService } from '../services'
 import {

--- a/packages/clients/dish/src/utils/extendGfi.ts
+++ b/packages/clients/dish/src/utils/extendGfi.ts
@@ -127,8 +127,6 @@ async function getHitInSearch(identifier: string): Promise<string> {
   return resultURL
 }
 
-// length seems acceptable, it's just some if/else domain logic
-// eslint-disable-next-line max-lines-per-function
 export async function extendGfi(
   featuresByLayerId: Record<string, GeoJsonFeature[]>
 ): Promise<

--- a/packages/clients/generic/src/polar-client.ts
+++ b/packages/clients/generic/src/polar-client.ts
@@ -56,8 +56,6 @@ console.info(`@polar/client-generic: running in v${packageInfo.version}.`)
 
 setLayout(NineLayout)
 
-// this is fine for list-like setup functions
-// eslint-disable-next-line max-lines-per-function
 const addPlugins = (coreInstance: PolarCore, enabledPlugins: PluginName[]) => {
   const iconMenu =
     enabledPlugins.includes('icon-menu') &&

--- a/packages/clients/meldemichel/src/addPlugins.ts
+++ b/packages/clients/meldemichel/src/addPlugins.ts
@@ -12,8 +12,6 @@ import Toast from '@polar/plugin-toast'
 import { MODE } from './enums'
 import createMenus from './utils/createMenus'
 
-// this is an acceptable length for list-like functions
-// eslint-disable-next-line max-lines-per-function
 export const addPlugins = (core, mode: keyof typeof MODE) => {
   const iconMenu = IconMenu({
     initiallyOpen: 'layerChooser',

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -148,8 +148,6 @@ const mapConfigurations: Record<
   keyof typeof MODE,
   (reportServiceId: string, afmUrl: string) => object
 > = {
-  // this is acceptable for configuration
-  // eslint-disable-next-line max-lines-per-function
   [MODE.COMPLETE]: (reportServiceId: string, afmUrl: string) => {
     return {
       ...commonMapConfiguration,

--- a/packages/clients/meldemichel/src/store/module.ts
+++ b/packages/clients/meldemichel/src/store/module.ts
@@ -37,8 +37,6 @@ const meldemichelModule: PolarModule<
   namespaced: true,
   state: {},
   actions: {
-    // length deemed acceptable due to function simplicity (forwarder)
-    // eslint-disable-next-line max-lines-per-function
     setMapState: (
       { commit, dispatch, rootGetters },
       {

--- a/packages/clients/snowbox/src/addPlugins.ts
+++ b/packages/clients/snowbox/src/addPlugins.ts
@@ -22,8 +22,6 @@ const defaultOptions = {
   layoutTag: NineLayoutTag.TOP_LEFT,
 }
 
-// this is acceptable for list-like functions
-// eslint-disable-next-line max-lines-per-function
 export const addPlugins = (core) => {
   setLayout(NineLayout)
 

--- a/packages/clients/snowbox/src/exampleFeatureInformation.ts
+++ b/packages/clients/snowbox/src/exampleFeatureInformation.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention, max-lines */
+/* eslint-disable @typescript-eslint/naming-convention */
 
 import { FeaturesByLayerId } from '@polar/plugin-gfi/src/types'
 

--- a/packages/clients/textLocator/src/addPlugins.ts
+++ b/packages/clients/textLocator/src/addPlugins.ts
@@ -29,8 +29,6 @@ export const ids = {
   typeLiterature: 'literature',
 }
 
-// this is fine for list-like setup functions
-// eslint-disable-next-line max-lines-per-function
 export const addPlugins = (core) => {
   setLayout(NineLayout)
 

--- a/packages/clients/textLocator/src/plugins/GeometrySearch/store/index.ts
+++ b/packages/clients/textLocator/src/plugins/GeometrySearch/store/index.ts
@@ -31,8 +31,6 @@ const getInitialState = (): GeometrySearchState => ({
   lastSearch: null,
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   const storeModule: PolarModule<GeometrySearchState, GeometrySearchGetters> = {
     namespaced: true,

--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -44,8 +44,6 @@
 </template>
 
 <script lang="ts">
-// it's complex, can't really be helped
-/* eslint-disable max-lines */
 import Vue, { PropType } from 'vue'
 import { mapActions, mapGetters, mapMutations } from 'vuex'
 import api from '@masterportal/masterportalapi/src/maps/api'

--- a/packages/core/src/vuePlugins/actions/useExtendedMasterportalapiMarkers/index.ts
+++ b/packages/core/src/vuePlugins/actions/useExtendedMasterportalapiMarkers/index.ts
@@ -67,8 +67,6 @@ export function updateSelection(
   }
 }
 
-// disabled since most of the body relies on parameters; allow longer function to avoid parameter explosion
-// eslint-disable-next-line max-lines-per-function
 export function useExtendedMasterportalapiMarkers(
   this: PolarStore<CoreState, CoreGetters>,
   { commit, dispatch, getters }: PolarActionContext<CoreState, CoreGetters>,

--- a/packages/core/src/vuePlugins/vuex.ts
+++ b/packages/core/src/vuePlugins/vuex.ts
@@ -82,8 +82,6 @@ const getInitialState = (): CoreState => ({
   oidcToken: '',
 })
 
-// OK for store creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStore = (mapConfiguration: MapConfig) => {
   /*
    * NOTE: The following variables are used to store complex information

--- a/packages/plugins/AddressSearch/src/store/actions.ts
+++ b/packages/plugins/AddressSearch/src/store/actions.ts
@@ -45,8 +45,6 @@ const getResultsFromPromises = (
   return results
 }
 
-// OK for module action set creation
-// eslint-disable-next-line max-lines-per-function
 export const makeActions = () => {
   let abortController
   let debouncedLoad

--- a/packages/plugins/Attributions/src/store/index.ts
+++ b/packages/plugins/Attributions/src/store/index.ts
@@ -13,8 +13,6 @@ const getInitialState = (): AttributionsState => ({
   windowIsOpen: false,
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   const storeModule: PolarModule<AttributionsState, AttributionsGetters> = {
     namespaced: true,

--- a/packages/plugins/Draw/src/store/actions.ts
+++ b/packages/plugins/Draw/src/store/actions.ts
@@ -17,8 +17,6 @@ import modifyTextStyle from './createInteractions/modifyTextStyle'
 import createDrawInteractions from './createInteractions/createDrawInteractions'
 import createDeleteInteractions from './createInteractions/createDeleteInteractions'
 
-// OK for module action set creation
-// eslint-disable-next-line max-lines-per-function
 export const makeActions = () => {
   let interactions: Interaction[] = []
   let drawLayer

--- a/packages/plugins/Draw/src/store/createInteractions/createLassoInteractions.ts
+++ b/packages/plugins/Draw/src/store/createInteractions/createLassoInteractions.ts
@@ -69,8 +69,6 @@ const buildAddFeaturesPayload = (
   }
 }
 
-// should be fine, surrounding method is only unpacking/packing, also see below
-// eslint-disable-next-line max-lines-per-function
 export default function ({
   rootGetters,
   getters,
@@ -79,8 +77,6 @@ export default function ({
 }: PolarActionContext<DrawState, DrawGetters>) {
   const draw = new Draw({ type: 'Polygon', freehand: true })
 
-  // should be fine, line bloat is from error handling (only logging/toasting)
-  // eslint-disable-next-line max-lines-per-function
   draw.on('drawend', (e) => {
     const toast = (toastObject) =>
       getters.toastAction &&

--- a/packages/plugins/Draw/src/store/index.ts
+++ b/packages/plugins/Draw/src/store/index.ts
@@ -23,8 +23,6 @@ const getInitialState = (): DrawState => ({
   measureMode: 'none',
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   // NOTE hack to keep complex objects out of vuex
   let selectedFeature = null

--- a/packages/plugins/Filter/src/store/index.ts
+++ b/packages/plugins/Filter/src/store/index.ts
@@ -25,8 +25,6 @@ const getInitialState = (): FilterState => ({
   time: {},
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   const storeModule: PolarModule<FilterState, FilterGetters> = {
     namespaced: true,

--- a/packages/plugins/GeoLocation/src/store/actions.ts
+++ b/packages/plugins/GeoLocation/src/store/actions.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines-per-function */
 import { PolarActionTree } from '@polar/lib-custom-types'
 import VectorLayer from 'ol/layer/Vector'
 import Point from 'ol/geom/Point'

--- a/packages/plugins/Gfi/src/store/actions/debouncedGfiRequest.ts
+++ b/packages/plugins/Gfi/src/store/actions/debouncedGfiRequest.ts
@@ -122,7 +122,6 @@ const errorSymbol = (err) => Symbol(err)
  * (and such effects are to be expected across the system), we're debouncing
  * this *after* resetting the module state, as something is bound to happen.
  */
-// eslint-disable-next-line max-lines-per-function
 const gfiRequest =
   (featureDisplayLayer: VectorLayer) =>
   async (

--- a/packages/plugins/Gfi/src/store/actions/index.ts
+++ b/packages/plugins/Gfi/src/store/actions/index.ts
@@ -12,8 +12,6 @@ import { debouncedGfiRequest } from './debouncedGfiRequest'
 import { setupCoreListener, setupTooltip, setupZoomListeners } from './setup'
 import { setupMultiSelection } from './setupMultiSelection'
 
-// OK for module action set creation
-// eslint-disable-next-line max-lines-per-function
 export const makeActions = () => {
   const writer = new GeoJSON()
   const featureDisplayLayer = getFeatureDisplayLayer()

--- a/packages/plugins/Gfi/src/store/actions/setupMultiSelection.ts
+++ b/packages/plugins/Gfi/src/store/actions/setupMultiSelection.ts
@@ -43,8 +43,6 @@ const drawOptions: DrawOptions = {
   condition: () => false,
 }
 
-// NOTE: This disable can be removed once the deprecated parameter 'boxSelect' has been removed
-// eslint-disable-next-line max-lines-per-function
 export function setupMultiSelection({
   dispatch,
   getters: {

--- a/packages/plugins/Gfi/src/utils/requestGfiWfs.ts
+++ b/packages/plugins/Gfi/src/utils/requestGfiWfs.ts
@@ -30,8 +30,6 @@ const xml2GeoJson = (
  * no new request should be started. Instead, wait for any running load to
  * finish and use feature at layer source coordinate. (Not trivial.)
  */
-// NOTE length comes from string build, not complexity – keep as it is
-// eslint-disable-next-line max-lines-per-function
 export default ({
   map,
   coordinateOrExtent,

--- a/packages/plugins/IconMenu/src/store/index.ts
+++ b/packages/plugins/IconMenu/src/store/index.ts
@@ -11,8 +11,6 @@ const getInitialState = (): IconMenuState => ({
   open: null,
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   const storeModule: PolarModule<IconMenuState, IconMenuGetters> = {
     namespaced: true,

--- a/packages/plugins/LayerChooser/src/store/index.ts
+++ b/packages/plugins/LayerChooser/src/store/index.ts
@@ -25,8 +25,6 @@ export const getInitialState = (): LayerChooserState => ({
   activeLayerIds: {},
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   const storeModule: PolarModule<LayerChooserState, LayerChooserGetters> = {
     namespaced: true,

--- a/packages/plugins/Pins/src/store/index.ts
+++ b/packages/plugins/Pins/src/store/index.ts
@@ -15,8 +15,6 @@ import { getPinStyle } from '../util/getPinStyle'
 import { getInitialState } from './state'
 import getters from './getters'
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   let pinsLayer: VectorLayer
   const move = new Select({

--- a/packages/plugins/ReverseGeocoder/src/store/index.ts
+++ b/packages/plugins/ReverseGeocoder/src/store/index.ts
@@ -4,8 +4,6 @@ import Point from 'ol/geom/Point'
 import { reverseGeocode } from '../utils/reverseGeocode'
 import { ReverseGeocoderFeature } from '../types'
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   let loaderCounter = 0
 

--- a/packages/plugins/Scale/src/store/index.ts
+++ b/packages/plugins/Scale/src/store/index.ts
@@ -16,8 +16,6 @@ const getInitialState = (): ScaleState => ({
   scaleWithUnit: '',
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   const storeModule: PolarModule<ScaleState, ScaleGetters> = {
     namespaced: true,

--- a/packages/plugins/Toast/src/store/index.ts
+++ b/packages/plugins/Toast/src/store/index.ts
@@ -25,8 +25,6 @@ export const getInitialState = (): ToastState => ({
   },
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   const storeModule: PolarModule<ToastState, ToastState> = {
     namespaced: true,

--- a/packages/plugins/Zoom/src/store/index.ts
+++ b/packages/plugins/Zoom/src/store/index.ts
@@ -11,8 +11,6 @@ const getInitialState = (): ZoomState => ({
   minimumZoomLevel: 0,
 })
 
-// OK for module creation
-// eslint-disable-next-line max-lines-per-function
 export const makeStoreModule = () => {
   const storeModule: PolarModule<ZoomState, ZoomGetters> = {
     namespaced: true,

--- a/packages/types/custom/core.ts
+++ b/packages/types/custom/core.ts
@@ -1,5 +1,3 @@
-// pushing this boundary is fine for a type register
-/* eslint-disable max-lines */
 import { Feature, Map } from 'ol'
 import { Resource } from 'i18next'
 import { Options as Fill } from 'ol/style/Fill'


### PR DESCRIPTION
## Summary

The rules `max-lines` and `max-lines-per-function` have been purged.

## Relevant tickets, issues, et cetera

https://github.com/Dataport/polar/pull/247
