### PR TITLE
Fix/diplan layer options

### DIFF
--- a/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
+++ b/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
@@ -40,7 +40,8 @@
           </v-expansion-panel-header>
           <v-divider />
           <v-expansion-panel-content>
-            <template v-if="displaySelection">
+            <LayerChooserOptions v-if="displayOptionsForType[type]" />
+            <template v-else>
               <template v-for="({ name, id }, index) in masks">
                 <LayerWrapper
                   :key="`disabled-mask-${type}-${index}`"
@@ -62,7 +63,6 @@
                 <v-divider :key="index" />
               </template>
             </template>
-            <LayerChooserOptions v-else />
           </v-expansion-panel-content>
         </v-expansion-panel>
       </template>
@@ -89,6 +89,7 @@ export default Vue.extend({
       'backgrounds',
       'disabledBackgrounds',
       'disabledMasks',
+      'displayOptionsForType',
       'masksSeparatedByType',
       'openedOptions',
       'shownMasks',
@@ -108,9 +109,6 @@ export default Vue.extend({
       set(value) {
         this.setActiveMaskIds(value)
       },
-    },
-    displaySelection() {
-      return this.openedOptions === null
     },
   },
   methods: {

--- a/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
+++ b/packages/clients/diplan/src/plugins/LayerChooser/LayerChooser.vue
@@ -91,7 +91,6 @@ export default Vue.extend({
       'disabledMasks',
       'displayOptionsForType',
       'masksSeparatedByType',
-      'openedOptions',
       'shownMasks',
     ]),
     activeBackground: {

--- a/packages/plugins/LayerChooser/src/store/index.ts
+++ b/packages/plugins/LayerChooser/src/store/index.ts
@@ -233,11 +233,11 @@ export const makeStoreModule = () => {
           .map((layer) => layer.id)
       },
       masksSeparatedByType: (_, { shownMasks }) =>
-        shownMasks.reduce((acc, masks) => {
-          if (Object.keys(acc).includes(masks.type)) {
-            return { ...acc, [masks.type]: [...acc[masks.type], masks] }
+        shownMasks.reduce((acc, mask) => {
+          if (Object.keys(acc).includes(mask.type)) {
+            return { ...acc, [mask.type]: [...acc[mask.type], mask] }
           }
-          return { ...acc, [masks.type]: [masks] }
+          return { ...acc, [mask.type]: [mask] }
         }, {}),
       openedOptionsService(_, { backgrounds, masks, openedOptions }) {
         return [...backgrounds, ...masks].find(

--- a/packages/plugins/LayerChooser/src/store/index.ts
+++ b/packages/plugins/LayerChooser/src/store/index.ts
@@ -213,6 +213,16 @@ export const makeStoreModule = () => {
           )
           .map((index) => index === -1)
       },
+      displayOptionsForType: (_, { masksSeparatedByType, openedOptions }) =>
+        Object.entries(masksSeparatedByType).reduce(
+          (acc, [type, masks]) => ({
+            ...acc,
+            [type]:
+              openedOptions !== null &&
+              masks.map(({ id }) => id).includes(openedOptions),
+          }),
+          {}
+        ),
       idsWithOptions(_, { backgrounds, masks }) {
         return [...backgrounds, ...masks]
           .filter((layer) => Boolean(layer.options))

--- a/packages/plugins/LayerChooser/src/store/index.ts
+++ b/packages/plugins/LayerChooser/src/store/index.ts
@@ -219,11 +219,11 @@ export const makeStoreModule = () => {
           .map((layer) => layer.id)
       },
       masksSeparatedByType: (_, { shownMasks }) =>
-        shownMasks.reduce((acc, mask) => {
-          if (Object.keys(acc).includes(mask.type)) {
-            return { ...acc, [mask.type]: [...acc[mask.type], mask] }
+        shownMasks.reduce((acc, masks) => {
+          if (Object.keys(acc).includes(masks.type)) {
+            return { ...acc, [masks.type]: [...acc[masks.type], masks] }
           }
-          return { ...acc, [mask.type]: [mask] }
+          return { ...acc, [masks.type]: [masks] }
         }, {}),
       openedOptionsService(_, { backgrounds, masks, openedOptions }) {
         return [...backgrounds, ...masks].find(

--- a/packages/plugins/LayerChooser/src/types.ts
+++ b/packages/plugins/LayerChooser/src/types.ts
@@ -21,6 +21,7 @@ export interface LayerChooserGetters extends LayerChooserState {
   component: VueConstructor | null
   disabledBackgrounds: boolean[]
   disabledMasks: boolean[]
+  displayOptionsForType: Record<string, boolean>
   idsWithOptions: string[]
   masksSeparatedByType: Record<string, LayerConfiguration[]>
   openedOptionsService: LayerConfiguration


### PR DESCRIPTION
## Summary

Change the way the options are opened in `@polar/client-diplan`.
Note that only one options menu can be open at once as this is the implementation currently used in the plugin. I wouldn't touch this though, as the implementation of the plugin itself has not been touched.

## Instructions for local reproduction and review

`npm run diplan:dev`

## Pull Request Checklist (for Assignee)

- ~~[] Changelogs are maintained~~ - not sure if a changelog entry for LayerChooser is needed though; in diplan this is not needed as the feature for the different groups is not published yet
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA - When navigating the options menu via keyboard, the whole application is focused after switching from / to the Options instead of an element in the menu. This is something I'll tackle in a separate PR

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility
