### PR TITLE
fix measurement calculation

### DIFF
--- a/packages/plugins/Draw/CHANGELOG.md
+++ b/packages/plugins/Draw/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Measurements were off. The calculation has been fixed.
+
 ## 3.1.0
 
 - Feature: Add a `"translate"` mode that allows moving drawn features as they are.

--- a/packages/plugins/Draw/src/utils/createDrawStyle.ts
+++ b/packages/plugins/Draw/src/utils/createDrawStyle.ts
@@ -11,7 +11,7 @@ import Style, { type Options, StyleFunction } from 'ol/style/Style'
 import Text, { type Options as TextOptions } from 'ol/style/Text'
 
 const roundMeasurement = (measurement: number, divisor: number) =>
-  Math.round(measurement / divisor + Number.EPSILON * 100) / 100
+  Math.round((measurement * 100) / divisor + Number.EPSILON) / 100
 
 function calculatePartialDistances(
   styles: Style[],


### PR DESCRIPTION
## Summary

Fix measurement calculation.

## Instructions for local reproduction and review

Visible in e.g. Snowbox. Außenalster has about a km width at its largest, but you may use other things of known size.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, ~~Chrome, Safari~~ numbers work the same way in all browsers
