### PR TITLE
Fix/mobile gfi

### DIFF
--- a/packages/plugins/Gfi/CHANGELOG.md
+++ b/packages/plugins/Gfi/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: When using the gfi with `renderType` set to `'independent'` the window was not added to the MoveHandle to be displayed on mobile devices. Also, the closeIcon was incorrectly set if `ƒeatureList` was configured. This has been fixed by watching for changes to `windowFeatures`.
+
 ## 3.0.2
 
 - Fix: Allow layers that have `singleTile` set to `true` and thus being an `ImageLayer` instead a `TileLayer` to be used for GFI-requests as well.

--- a/packages/plugins/Gfi/src/components/Gfi.vue
+++ b/packages/plugins/Gfi/src/components/Gfi.vue
@@ -25,14 +25,11 @@ export default Vue.extend({
   computed: {
     ...mapGetters(['moveHandle']),
     ...mapGetters('plugin/gfi', [
-      'currentProperties',
-      'exportPropertyLayerKeys',
       'gfiContentComponent',
       'gfiConfiguration',
       'renderMoveHandle',
       'renderType',
       'showList',
-      'visibleWindowFeatureIndex',
       'windowFeatures',
       'windowLayerKeysActive',
     ]),

--- a/packages/plugins/Gfi/src/components/Gfi.vue
+++ b/packages/plugins/Gfi/src/components/Gfi.vue
@@ -3,16 +3,11 @@
     <v-card v-if="!windowLayerKeysActive">
       <v-card-text>{{ $t('plugins.gfi.noActiveLayer') }}</v-card-text>
     </v-card>
-    <component
-      :is="contentComponent"
-      v-else-if="!renderMoveHandle"
-      v-bind="contentProps"
-    />
+    <component :is="contentComponent" v-else-if="!renderMoveHandle" />
   </div>
 </template>
 
 <script lang="ts">
-import compare from 'just-compare'
 import { t } from 'i18next'
 import Vue from 'vue'
 import { mapActions, mapGetters, mapMutations } from 'vuex'
@@ -36,37 +31,25 @@ export default Vue.extend({
     contentComponent(): Vue {
       return this.showList ? List : this.gfiContentComponent || Feature
     },
-    contentProps(): object {
-      return this.showList ? {} : {}
-    },
     moveHandleProperties() {
-      const properties: MoveHandleProperties = {
+      return {
         closeIcon: this.gfiConfiguration.featureList
           ? 'fa-angles-right'
           : 'fa-xmark',
         closeLabel: t('plugins.gfi.header.close'),
         closeFunction: this.closeWindow,
         component: this.contentComponent,
-        props: this.contentProps,
         plugin: this.renderType === 'independent' ? 'gfi' : 'iconMenu',
-      }
-
-      return properties
+      } as MoveHandleProperties
     },
     renderUi(): boolean {
       return this.windowFeatures.length > 0 || this.showList
     },
   },
   watch: {
-    moveHandleProperties(
-      newProperties: MoveHandleProperties,
-      oldProperties: MoveHandleProperties
-    ) {
-      if (
-        this.windowFeatures.length &&
-        !compare(newProperties, oldProperties)
-      ) {
-        this.setMoveHandle(newProperties)
+    windowFeatures() {
+      if (this.windowFeatures.length) {
+        this.setMoveHandle(this.moveHandleProperties)
       } else if (
         !this.windowFeatures.length &&
         this.moveHandle !== null &&


### PR DESCRIPTION
## Summary

After removing several computed values and props in #131 the mutation to set the gfi in the MoveHandle through the watcher was no longer triggering as the values of moveHandleProperties were always the same.

Now, the GFI window is displayed again on mobile devices when it's rendered independently and the closeIcon is now again fa-angles-right when featureList is configured.

~~Note that a plugin opened in the IconMenu still disappears when resizing to a smaller width. This is a separate issue I'll tackle in another PR.~~ That is now fixed in #307.

## Instructions for local reproduction and review

Check both `@polar/client-meldemichel` and `@polar/client-dish` if the window is rendered properly on small devices

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera

Bug was introduced in #131