### PR TITLE
Remove redundant if-statement breaking the open menu on resize

### DIFF
--- a/packages/plugins/IconMenu/CHANGELOG.md
+++ b/packages/plugins/IconMenu/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: Adjust behaviour of setting content to the MoveHandle for small devices so that an already opened plugin is still open on resize.
+
 ## 1.4.0
 
 - Feature: Add new configuration parameter `buttonComponent` to be able to interchange the UI component of the used (icon) buttons.

--- a/packages/plugins/IconMenu/src/store/index.ts
+++ b/packages/plugins/IconMenu/src/store/index.ts
@@ -66,22 +66,20 @@ export const makeStoreModule = () => {
           dispatch('openInMoveHandle', index)
         }
       },
-      openInMoveHandle({ commit, getters, rootGetters }, index: number) {
-        if (rootGetters.hasWindowSize && rootGetters.hasSmallWidth) {
-          const { hint, id, plugin } = getters.menus[index]
-          commit(
-            'setMoveHandle',
-            {
-              closeLabel: t('plugins.iconMenu.mobileCloseButton', {
-                plugin: hint || `plugins.iconMenu.hints.${id}`,
-              }),
-              closeFunction: () => commit('setOpen', null),
-              component: plugin,
-              plugin: 'iconMenu',
-            },
-            { root: true }
-          )
-        }
+      openInMoveHandle({ commit, getters }, index: number) {
+        const { hint, id, plugin } = getters.menus[index]
+        commit(
+          'setMoveHandle',
+          {
+            closeLabel: t('plugins.iconMenu.mobileCloseButton', {
+              plugin: hint || `plugins.iconMenu.hints.${id}`,
+            }),
+            closeFunction: () => commit('setOpen', null),
+            component: plugin,
+            plugin: 'iconMenu',
+          },
+          { root: true }
+        )
       },
     },
     mutations: {

--- a/packages/plugins/IconMenu/tests/store.spec.ts
+++ b/packages/plugins/IconMenu/tests/store.spec.ts
@@ -69,12 +69,6 @@ describe('plugin-icon-menu', () => {
 
           expect(dispatch.mock.calls.length).toEqual(0)
         })
-        it('should do nothing if the client either does not have the same size as the window or the width of the client is considered large', () => {
-          storeModule.actions.openInMoveHandle(actionContext, 0)
-
-          expect(commit.mock.calls.length).toEqual(0)
-          expect(dispatch.mock.calls.length).toEqual(0)
-        })
       })
     })
   })


### PR DESCRIPTION
## Summary

Fix issue of an opened icon menu plugin disappearing when resizing or changing the orientation of a mobile device.

## Instructions for local reproduction and review

`npm run meldemichel:dev` and resize / change orientation for mobile simulation when a plugin is open. It should now stay open.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- ~~[ ] Functionality has been tested with 200% screen zoom~~
- ~~[ ] Screenreader functionality has been manually tested with NVDA~~

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility
