### PR TITLE
dish client: set mode to extern

### DIFF
--- a/packages/clients/dish/src/index.html
+++ b/packages/clients/dish/src/index.html
@@ -39,7 +39,7 @@
 
       client.createMap({
         containerId: 'polarstern',
-        mode: 'INTERN', // INTERN, EXTERN
+        mode: 'EXTERN', // INTERN, EXTERN
         urlParams,
         // only needed for the internal map
         configOverride: {


### PR DESCRIPTION
## Summary

The mode 'extern' is now set as default in the index.html.

## Instructions for local reproduction and review
-

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
