### PR TITLE
add default values to config in all spots

### DIFF
--- a/packages/core/src/utils/createMap/index.ts
+++ b/packages/core/src/utils/createMap/index.ts
@@ -33,22 +33,24 @@ export default async function createMap({
     externalStylesheet.id = 'vuetify-theme-stylesheet-external'
   }
 
+  const defaultedConfiguration = { ...defaults, ...mapConfiguration }
+
   const instance: MapInstance = new Vue({
-    vuetify: vuetify(mapConfiguration?.vuetify),
+    vuetify: vuetify(defaultedConfiguration?.vuetify),
     el: shadowRoot.appendChild(document.createElement('div')),
     render: (createElement) =>
       createElement(MapContainer, {
         props: {
-          mapConfiguration: { ...defaults, ...mapConfiguration },
+          mapConfiguration: defaultedConfiguration,
         },
       }),
-    store: makeStore(mapConfiguration),
+    store: makeStore(defaultedConfiguration),
   })
   instance.subscribe = subscribeFunction
 
-  pullPolarStyleToShadow(shadowRoot, mapConfiguration.stylePath)
+  pullPolarStyleToShadow(shadowRoot, defaultedConfiguration.stylePath)
   pullVuetifyStyleToShadow(shadowRoot)
-  setupFontawesome(shadowRoot, mapConfiguration.renderFaToLightDom)
+  setupFontawesome(shadowRoot, defaultedConfiguration.renderFaToLightDom)
   updateSizeOnReady(instance)
 
   // Restore theme ID such that external Vuetify app can find it again


### PR DESCRIPTION
## Summary

A prior refactor broke the defaulting; not all targets also got the default values as a baseline, due to what e.g. the `epsg` value was missing in BKG address search as configured in the bgw client. Now it's made sure that the default values are used everywhere, also if we later add additional default values.

## Instructions for local reproduction and review

See that e.g. `npm run bgw:dev` has a working BKG address search again.

## Pull Request Checklist (for Assignee)

No changelog entry required since there was no release since the bug appeared and it in itself was merely a refactor.

## Relevant tickets, issues, et cetera

Was broken in https://github.com/Dataport/polar/pull/297.
