### PR TITLE
Addition of a login example to @polar/client-snowbox

### DIFF
--- a/packages/clients/snowbox/src/authentication.ts
+++ b/packages/clients/snowbox/src/authentication.ts
@@ -1,0 +1,120 @@
+const clientId = 'polar'
+const scope = 'openid'
+
+// These values are based on the respective KeyCloak configuration
+const authenticationUrl = ''
+const revokeTokenUrl = ''
+const refreshTokenUrl = ''
+
+const loginButton = document.getElementById('login-button') as HTMLButtonElement
+const usernameInput = document.getElementById('username') as HTMLInputElement
+const passwordInput = document.getElementById('password') as HTMLInputElement
+const errorMessage = document.getElementById(
+  'error-message'
+) as HTMLParagraphElement
+
+let loggedIn = false
+let token: string
+let refreshToken: string
+
+export async function authenticate(
+  username: string,
+  password: string,
+  setTokenMethod: (token: string) => void
+) {
+  if (loggedIn) {
+    await reset()
+    return
+  }
+
+  const response = await fetch(authenticationUrl, {
+    method: 'POST',
+    headers: {
+      // The header is defined like that
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    },
+    body: `grant_type=password&client_id=${encodeURIComponent(
+      clientId
+    )}&username=${encodeURIComponent(username)}&password=${encodeURIComponent(
+      password
+    )}&scope=${encodeURIComponent(scope)}`,
+  })
+  if (response.ok) {
+    const data = await response.json()
+    token = data.access_token
+    refreshToken = data.refresh_token
+    setTokenMethod(token)
+
+    loginButton.textContent = 'Logout'
+    usernameInput.disabled = true
+    passwordInput.disabled = true
+
+    loggedIn = true
+
+    setTimeout(
+      () => requestNewToken(setTokenMethod),
+      (data.expires_in - 15) * 1000
+    )
+    return
+  }
+  errorMessage.textContent =
+    'Die angegebene Kombination aus Nutzername und Passwort ist nicht korrekt.'
+}
+
+async function reset() {
+  await revokeToken()
+  window.location.reload()
+}
+
+async function revokeToken() {
+  const response = await fetch(revokeTokenUrl, {
+    method: 'POST',
+    headers: {
+      // The header is defined like that
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    },
+    body: `grant_type=refresh_token&token=${encodeURIComponent(
+      token
+    )}&client_id=${encodeURIComponent(clientId)}`,
+  })
+  if (response.ok) {
+    return
+  }
+  errorMessage.textContent = 'Der Nutzer konnte nicht abgemeldet werden.'
+}
+
+async function requestNewToken(setTokenMethod) {
+  const response = await fetch(refreshTokenUrl, {
+    method: 'POST',
+    headers: {
+      // The header is defined like that
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+    },
+    body: `grant_type=refresh_token&refresh_token=${encodeURIComponent(
+      refreshToken
+    )}&client_id=${encodeURIComponent(clientId)}&scope=${encodeURIComponent(
+      scope
+    )}`,
+  })
+  if (response.ok) {
+    const data = await response.json()
+    token = data.access_token
+    refreshToken = data.refresh_token
+    setTokenMethod(token)
+
+    setTimeout(
+      () => requestNewToken(setTokenMethod),
+      (data.expires_in - 15) * 1000
+    )
+    return
+  }
+  errorMessage.textContent =
+    'Die Session ist ausgelaufen und der Token konnte nicht erneuert werden.'
+  loginButton.textContent = 'Login'
+  usernameInput.disabled = false
+  passwordInput.disabled = false
+  loggedIn = false
+}

--- a/packages/clients/snowbox/src/html/index.html
+++ b/packages/clients/snowbox/src/html/index.html
@@ -82,6 +82,20 @@
     <p>
       Please mind you have to generate it locally first with `npm run docs:snowbox`, or use the public version <a target="_blank" href="https://dataport.github.io/polar/">here</a>.
     </p>
+    <h2>🔒 Loginbeispiel</h2>
+    <form id="login-form" style="display: flex; gap: 10px;">
+      <label>
+        Nutzername:
+        <input type="text" id="username" name="username" required>
+      </label>
+      <label>
+        Passwort:
+        <input type="password" id="password" name="password" required>
+      </label>
+      <br>
+      <button id="login-button" type="button">Login</button>
+    </form>
+    <p id="error-message" style="color: red;"></p>
     <h2>🗺️ Map</h2>
     <p>In this example, the map client is used as an element on a website.</p>
     <label id="language-switcher-label">

--- a/packages/clients/snowbox/src/index.html
+++ b/packages/clients/snowbox/src/index.html
@@ -82,6 +82,20 @@
     <p>
       Please mind you have to generate it locally first with `npm run docs:snowbox`, or use the public version <a target="_blank" href="https://dataport.github.io/polar/">here</a>.
     </p>
+    <h2>🔒 Loginbeispiel</h2>
+    <form id="login-form" style="display: flex; gap: 10px;">
+      <label>
+        Nutzername:
+        <input type="text" id="username" name="username" required>
+      </label>
+      <label>
+        Passwort:
+        <input type="password" id="password" name="password" required>
+      </label>
+      <br>
+      <button id="login-button" type="button">Login</button>
+    </form>
+    <p id="error-message" style="color: red;"></p>
     <h2>🗺️ Map</h2>
     <p>In this example, the map client is used as an element on a website.</p>
     <label id="language-switcher-label">

--- a/packages/clients/snowbox/src/polar-client.ts
+++ b/packages/clients/snowbox/src/polar-client.ts
@@ -6,6 +6,7 @@ import { enableClustering } from '../../meldemichel/src/utils/enableClustering'
 import { addPlugins } from './addPlugins'
 import { flurstuecke, mapConfiguration, reports } from './mapConfiguration'
 import { exampleFeatureInformation } from './exampleFeatureInformation'
+import { validateForm } from './validateForm'
 
 addPlugins(polarCore)
 
@@ -28,6 +29,13 @@ const createMap = (layerConf) => {
     .then((map) => {
       // @ts-expect-error | adding it intentionally for e2e testing
       window.mapInstance = map
+
+      const loginButton = document.getElementById(
+        'login-button'
+      ) as HTMLButtonElement
+      loginButton.onclick = () =>
+        validateForm((token) => map.$store.commit('setOidcToken', token))
+
       addStoreSubscriptions(
         ['plugin/zoom/zoomLevel', 'vuex-target-zoom'],
         [

--- a/packages/clients/snowbox/src/validateForm.ts
+++ b/packages/clients/snowbox/src/validateForm.ts
@@ -1,0 +1,19 @@
+import { authenticate } from './authentication'
+
+export function validateForm(setTokenMethod: (token: string) => void) {
+  const username = (document.getElementById('username') as HTMLInputElement)
+    .value
+  const password = (document.getElementById('password') as HTMLInputElement)
+    .value
+  const errorMessage = document.getElementById(
+    'error-message'
+  ) as HTMLParagraphElement
+
+  if (!username || !password) {
+    errorMessage.textContent =
+      'Bitte geben Sie sowohl einen Nutzernamen als auch ein Passwort ein.'
+  } else {
+    errorMessage.textContent = ''
+    authenticate(username, password, setTokenMethod)
+  }
+}


### PR DESCRIPTION
## Summary

Add an example on how to login and save the token to @polar/client-snowbox.
This should subsequently be updated including a service and a keycloak server with which one can showcase the usage of secured services. This should be added in a separate PR once we've got ahold of those things.

## Instructions for local reproduction and review

`npm run snowbox` and check that you can login with the previously provided credentials. Note that a CORS plugin is required.

## Relevant tickets, issues, et cetera

Example based on removed example from #311