### PR TITLE
Remove need to call initializeLayerList for local service registers

### DIFF
--- a/gettingStarted.md
+++ b/gettingStarted.md
@@ -239,8 +239,10 @@ const createMap = (layerConf) => {
     .then(addStoreSubscriptions(/* subscription logic */))
 }
 
-// Initializes the layer list and creates the map instance.
-// This becomes obsolete if a local service register is used.
+/* Initializes the layer list and creates the map instance.
+ * This becomes obsolete if a local service register is used.
+ * In that case, that service register can be directly used as `layerConf` on the `createMap` call.
+ */
 polarCore.rawLayerList.initializeLayerList(
   'https://geodienste.hamburg.de/services-internet.json',
   createMap

--- a/gettingStarted.md
+++ b/gettingStarted.md
@@ -239,7 +239,8 @@ const createMap = (layerConf) => {
     .then(addStoreSubscriptions(/* subscription logic */))
 }
 
-// Initializes the layer list and creates the map instance
+// Initializes the layer list and creates the map instance.
+// This is becomes obsolete once one uses a local service register.
 polarCore.rawLayerList.initializeLayerList(
   'https://geodienste.hamburg.de/services-internet.json',
   createMap

--- a/gettingStarted.md
+++ b/gettingStarted.md
@@ -240,7 +240,7 @@ const createMap = (layerConf) => {
 }
 
 // Initializes the layer list and creates the map instance.
-// This is becomes obsolete once one uses a local service register.
+// This becomes obsolete if a local service register is used.
 polarCore.rawLayerList.initializeLayerList(
   'https://geodienste.hamburg.de/services-internet.json',
   createMap

--- a/packages/clients/bgw/src/polar-client.ts
+++ b/packages/clients/bgw/src/polar-client.ts
@@ -12,8 +12,6 @@ const containerId = 'polarstern'
 addPlugins(client)
 
 async function initializeClient() {
-  client.rawLayerList.initializeLayerList(services)
-
   const clientInstance = await client.createMap({
     containerId,
     mapConfiguration: {

--- a/packages/clients/dish/src/polar-client.ts
+++ b/packages/clients/dish/src/polar-client.ts
@@ -22,7 +22,6 @@ export default {
   createMap: async ({ containerId, mode, urlParams, configOverride }) => {
     addPlugins(client, mode)
     const layerConf = services(mode, urlParams)
-    client.rawLayerList.initializeLayerList(layerConf)
     const mapConfiguration = getMapConfiguration(mode, urlParams)
 
     const map = await client.createMap({

--- a/packages/clients/textLocator/src/polar-client.ts
+++ b/packages/clients/textLocator/src/polar-client.ts
@@ -18,7 +18,6 @@ interface TextLocatorParameters {
 }
 
 export async function initializeClient({ urls }: TextLocatorParameters) {
-  client.rawLayerList.initializeLayerList(layerConf)
   mapConfiguration.layerConf = layerConf
   mapConfiguration.addressSearch = {
     searchMethods: [

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## unpublished
 
-- Feature: Remove need of calling `rawLayerList.initializeLayerList` when creating a client using a local service register.
 - Fix: Change `EPSG:31467` projection definition string to be usable for `proj` conversions.
 - Fix: List items that are currently highlighted according to vuetify (e.g. options in a select element) now by default have the primary color as outline to improve accessibility.
+- Chore: Add documentation regarding optionality of calling `rawLayerList.initializeLayerList` when creating a client using a local service register.
 - Chore: Add teardown hints for single page application to README file.
 
 ## 3.2.0

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unpublished
 
+- Feature: Remove need of calling `rawLayerList.initializeLayerList` when creating a client using a local service register.
 - Chore: Add teardown hints for single page application to README file.
 
 ## 3.2.0

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -57,11 +57,12 @@ If the storeModule features a `setupModule` action, it will be executed automati
 
 ### initializeLayerList
 
-Layers intended to be used in the map have to be initialized by calling `initializeLayerList` with a service register.  
-This register may either be a link to a predefined service register like [the Hamburg service register](https://geodienste.hamburg.de/services-internet.json), or the custom service register that is also used in [mapConfiguration.layerConf](#mapconfigurationlayerconf).
+Layer registers to be fetched from remote sources have to be initialized by calling `initializeLayerList` with their respective URL.
+The URL may e.g. point to a predefined service register like [the service register of the city of Hamburg](https://geodienste.hamburg.de/services-internet.json).
+In this case, `initializeLayerList` needs to be called before `createMap` and `initializeLayerList`'s callback will receive the retrieved [`mapConfiguration.layerConf`](#mapconfigurationlayerconf) as its first parameter.
 
-This is an optional step as `@masterportal/masterportalapi` already handles this.
-However, it becomes required again to call this an additional time when using a URL for the service register as some setups need to be done first before anything polar-related can be set up.
+If a local custom service register is being used, i.e. the [`mapConfiguration.layerConf`](#mapconfigurationlayerconf) is locally available as an array before calling `createMap`, it can be directly used as [`mapConfiguration.layerConf`](#mapconfigurationlayerconf) without calling `initializeLayerList`.
+The `@masterportal/masterportalapi` then handles the layer list setup in time.
 
 ```js
 core.rawLayerList.initializeLayerList(services: mapConfiguration.layerConf | string, callback?: Function)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -60,6 +60,9 @@ If the storeModule features a `setupModule` action, it will be executed automati
 Layers intended to be used in the map have to be initialized by calling `initializeLayerList` with a service register.  
 This register may either be a link to a predefined service register like [the Hamburg service register](https://geodienste.hamburg.de/services-internet.json), or the custom service register that is also used in [mapConfiguration.layerConf](#mapconfigurationlayerconf).
 
+This is an optional step as `@masterportal/masterportalapi` already handles this.
+However, it becomes required again to call this an additional time when using a URL for the service register as some setups need to be done first before anything polar-related can be set up.
+
 ```js
 core.rawLayerList.initializeLayerList(services: mapConfiguration.layerConf | string, callback?: Function)
 ```


### PR DESCRIPTION
## Summary

@masterportal/masterportalapi already handles this. It is important to note that it is an async function that can not be awaited when used with a URL. Thus, it becomes required to still call it a second time in such cases.

## Instructions for local reproduction and review

Run `bgw`, `dish` and `textLocator` and check whether they still run properly.
Note that dish may have some issues loading one feature layer in production mode, but that issue already exists on `main`.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility
