### PR TITLE
add region role to map div

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix: Change `EPSG:31467` projection definition string to be usable for `proj` conversions.
 - Fix: List items that are currently highlighted according to vuetify (e.g. options in a select element) now by default have the primary color as outline to improve accessibility.
+- Fix: Add role "region" to render div for a broader screen reader support on its aria-label.
 - Chore: Add teardown hints for single page application to README file.
 
 ## 3.2.0

--- a/packages/core/src/components/MapContainer.vue
+++ b/packages/core/src/components/MapContainer.vue
@@ -17,6 +17,7 @@
       ref="polar-map-container"
       class="polar-map"
       tabindex="0"
+      role="region"
       :aria-label="$t('canvas.label')"
     ></div>
     <MapUi></MapUi>


### PR DESCRIPTION
## Summary

A "region" role has been added to the render div.

* Chrome Lighthouse indicated that an `aria-label` on a `div` is insufficient.
* Supposedly JAWS doesn't read that `aria-label` without further ado: https://stackoverflow.com/questions/42681485/div-aria-label-not-being-read-by-jaws
* NVDA didn't care, we can't really tell if it helped except for the Lighthouse warning vanishing (maybe it matters in Safari VoiceOver?)

## Instructions for local reproduction and review

Run Chrome Lighthouse check.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility
