### PR TITLE
Dish: apply new gfi highlight

### DIFF
--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -146,6 +146,15 @@ export const mapConfigIntern = (urlParams: DishUrlParams): DishMapConfig => ({
       'plugin/pins/transformedCoordinate',
       'plugin/pins/coordinatesAfterDrag',
     ],
+    customHighlightStyle: {
+      stroke: {
+        color: '#FFFF00',
+        width: 3,
+      },
+      fill: {
+        color: 'rgb(255, 255, 255, 0.7)',
+      },
+    },
   },
   pins: {
     toZoomLevel: 8,


### PR DESCRIPTION
## Summary

Simple configuration changes: the gfi of the internal dish client is now yellow again.

## Instructions for local reproduction and review

- start the dish client in mode `INTERN`
- click on a monument object
- the highlighting should now be outlined yellow instead of blue.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
