### PR TITLE
Change reverseGeocode to an action to provide a side effect free action

### DIFF
--- a/packages/plugins/ReverseGeocoder/CHANGELOG.md
+++ b/packages/plugins/ReverseGeocoder/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## unpublished
+
+- Fix: Make action `reverseGeocode` actually callable like it is documented and fix its payload documentation.
+
 ## 3.0.0
 
 - Breaking: Upgrade peerDependency `ol` from `^9.2.4` to `^10.3.1`.

--- a/packages/plugins/ReverseGeocoder/README.md
+++ b/packages/plugins/ReverseGeocoder/README.md
@@ -42,8 +42,6 @@ The ReverseGeocoder plugin does not hold any state.
 // result contains the resolved address (exact format depends on WPS)
 const result = await map.$store.dispatch(
   'plugin/reverseGeocoder/reverseGeocode',
-  {
-    coordinate, // [number, number]
-  }
+  coordinate, // [number, number]
 )
 ```

--- a/packages/plugins/ReverseGeocoder/src/store/index.ts
+++ b/packages/plugins/ReverseGeocoder/src/store/index.ts
@@ -1,8 +1,8 @@
 import { PolarModule } from '@polar/lib-custom-types'
 import { easeOut } from 'ol/easing'
 import Point from 'ol/geom/Point'
-import { reverseGeocode } from '../utils/reverseGeocode'
 import { ReverseGeocoderFeature } from '../types'
+import { reverseGeocode } from './actions/reverseGeocode'
 
 export const makeStoreModule = () => {
   let loaderCounter = 0
@@ -38,15 +38,9 @@ export const makeStoreModule = () => {
         { rootGetters, commit, dispatch },
         coordinate: [number, number]
       ): Promise<ReverseGeocoderFeature | null> {
-        const { url, addressTarget, addLoading, removeLoading, zoomTo } =
+        const { addressTarget, addLoading, removeLoading, zoomTo } =
           rootGetters.configuration.reverseGeocoder || {}
         const { map } = rootGetters
-
-        if (!url) {
-          throw new Error(
-            'POLAR ReverseGeocoder#resolveCoordinate: No URL specified.'
-          )
-        }
 
         const localLoaderCounter = ++loaderCounter
         const loaderKey = `reverse-geocoder-load-${localLoaderCounter}`
@@ -58,7 +52,7 @@ export const makeStoreModule = () => {
         let feature: ReverseGeocoderFeature | null = null
 
         try {
-          feature = await reverseGeocode(url, coordinate)
+          feature = await dispatch('reverseGeocode', coordinate)
           if (localLoaderCounter === loaderCounter) {
             if (addressTarget) {
               dispatch(addressTarget, { feature }, { root: true })
@@ -84,6 +78,7 @@ export const makeStoreModule = () => {
 
         return feature
       },
+      reverseGeocode,
     },
     getters: {},
     mutations: {},

--- a/packages/plugins/ReverseGeocoder/tests/reverseGeocode.spec.ts
+++ b/packages/plugins/ReverseGeocoder/tests/reverseGeocode.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import { reverseGeocode } from '../src/utils/reverseGeocode'
+import { reverseGeocode } from '../src/store/actions/reverseGeocode'
 
 const testUrl = 'www.example.com/WPS'
 
@@ -66,8 +66,8 @@ const wpsMockResponse = `<?xml version='1.0' encoding='UTF-8'?>
 </wps:ExecuteResponse>`
 
 describe('plugin-reversegeocoder', () => {
-  describe('utils', () => {
-    describe('resolve', () => {
+  describe('actions', () => {
+    describe('reverseGeocode', () => {
       let fetch
       beforeEach(() => {
         fetch = global.fetch
@@ -82,7 +82,15 @@ describe('plugin-reversegeocoder', () => {
         global.fetch = fetch
       })
       it('fetches with the appropriate body', () => {
-        reverseGeocode(testUrl, testCoordinates)
+        reverseGeocode(
+          {
+            rootGetters: {
+              // @ts-ignore
+              configuration: { reverseGeocoder: { url: testUrl } },
+            },
+          },
+          testCoordinates
+        )
 
         // @ts-ignore | it's a mock
         const calls: Array = global.fetch.mock.calls
@@ -96,7 +104,15 @@ describe('plugin-reversegeocoder', () => {
         ])
       })
       it('reformats the return values correctly', async () => {
-        const feature = await reverseGeocode(testUrl, testCoordinates)
+        const feature = await reverseGeocode(
+          {
+            rootGetters: {
+              // @ts-ignore
+              configuration: { reverseGeocoder: { url: testUrl } },
+            },
+          },
+          testCoordinates
+        )
 
         expect(feature).toEqual({
           type: 'reverse_geocoded',


### PR DESCRIPTION
## Summary

The action `reverseGeocode` was formerly just a util function not available from the outside. Now, it can be called like documented.
Using resolveCoordinate instead would've led to unwanted additions to addressTarget.

## Instructions for local reproduction and review

`npm run meldemichel:dev` should still add addresses to the search if a user clicks in the map.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- ~~[ ] Functionality has been tested on a smartphone~~
- ~~[ ] Functionality has been tested with 200% screen zoom~~
- ~~[ ] Screenreader functionality has been manually tested with NVDA~~

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - ~~[ ] Chrome Lighthouse~~
  - ~~[ ] Firefox Accessibility~~

## Relevant tickets, issues, et cetera

Will be used in #323