### PR TITLE
use basemap as default baselayer

### DIFF
--- a/packages/clients/dish/src/mapConfigurations/layerConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/layerConfigIntern.ts
@@ -20,13 +20,13 @@ import {
 const layersIntern: LayerConfiguration[] = [
   {
     id: basemapGrau,
-    visibility: false,
+    visibility: true,
     type: 'background',
     name: 'Basemap.de Graustufen',
   },
   {
     id: bddEin,
-    visibility: true,
+    visibility: false,
     type: 'background',
     name: 'Grundkarte Graustufen',
   },


### PR DESCRIPTION
## Summary

Since the intranet services are not available for us, we decided to switch to basemap as default baselayer, at least for the test environment.

## Instructions for local reproduction and review

- start the dish client with `mode=INTERN` (to see the monument services you have to use the VPN connection, you might also need a browser addon to prevent CORS errors)
- check if the grey basemap is shown in the client

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
