### PR TITLE
Use updated layer id for the aerial photo layer

### DIFF
--- a/packages/clients/diplan/CHANGELOG.md
+++ b/packages/clients/diplan/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Feature: Use new implementation of `@polar/plugin-layer-chooser` in the custom component to be able to separate mask layers in different groups.
 - Feature: Add visual dividers between radio elements of the background layers.
 - Feature: Add additional layers to the examples.
+- Fix: Use updated layer id for the aerial photo layer.
 - Chore: Move implementation of duplicatePolygons, mergePolygons, cutPolygons, sfa validation, mergeToMultiGeometries, and meta service enrichment of features to `@polar/plugin-draw`.
 
 ## 1.0.0-beta.1

--- a/packages/clients/diplan/example/diplan-ui-one/config.js
+++ b/packages/clients/diplan/example/diplan-ui-one/config.js
@@ -1,7 +1,7 @@
 // service id map to avoid typos, ease renames
 const basemap = 'basemapde_farbe'
 const stadtplan = '453'
-const luftbilder = '452'
+const luftbilder = '34127'
 
 const xplanwms = 'xplanwms'
 const xplanwfs = 'xplanwfs'

--- a/packages/clients/diplan/example/diplan-ui-two/config.js
+++ b/packages/clients/diplan/example/diplan-ui-two/config.js
@@ -1,7 +1,7 @@
 // service id map to avoid typos, ease renames
 const basemap = 'basemapde_farbe'
 const stadtplan = '453'
-const luftbilder = '452'
+const luftbilder = '34127'
 
 const xplanwms = 'xplanwms'
 const xplanwfs = 'xplanwfs'

--- a/packages/clients/diplan/example/services.js
+++ b/packages/clients/diplan/example/services.js
@@ -459,7 +459,7 @@ export default [
     bboxCrs: 'http://www.opengis.net/def/crs/EPSG/0/25832',
   },
   {
-    id: '452',
+    id: '34127',
     name: 'Digitale Orthophotos (belaubt) Hamburg',
     url: 'https://geodienste.hamburg.de/HH_WMS_DOP_belaubt',
     typ: 'WMS',

--- a/packages/clients/diplan/src/config.js
+++ b/packages/clients/diplan/src/config.js
@@ -1,7 +1,7 @@
 // service id map to avoid typos, ease renames
 const basemap = 'basemapde_farbe'
 const stadtplan = '453'
-const luftbilder = '452'
+const luftbilder = '34127'
 
 const xplanwms = 'xplanwms'
 const xplanwfs = 'xplanwfs'

--- a/packages/clients/meldemichel/CHANGELOG.md
+++ b/packages/clients/meldemichel/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unpublished
 
+- Fix: Use updated layer id for the aerial photo layer.
 - Chore: Update `@polar`-dependencies to the latest versions.
 
 ## 1.2.1

--- a/packages/clients/meldemichel/src/mapConfigurations.ts
+++ b/packages/clients/meldemichel/src/mapConfigurations.ts
@@ -17,7 +17,7 @@ import { showTooltip } from './utils/showTooltip'
 
 export const stadtwald = '18746'
 const stadtplan = '453'
-const luftbilder = '452'
+const luftbilder = '34127'
 export const hamburgBorder = '1693' // boundary layer for pins / geolocalization
 
 const hamburgWhite = '#ffffff'


### PR DESCRIPTION
## Summary

The previous id has been removed from the service register and has been superseded by the one added in this PR.

## Instructions for local reproduction and review

Run meldemichel and check whether the aerial photo layer can be rendered again.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility