### PR TITLE
Introduce ADRs to main repo

### DIFF
--- a/docs-architecture/ADR-0001.md
+++ b/docs-architecture/ADR-0001.md
@@ -1,0 +1,19 @@
+# ADR 0001: We write ADRs from now on
+
+## Status
+
+Accepted.
+
+## Context
+
+As time goes by, it becomes unclear whether architectural decisions have been made accidentally or on purpose, and, if on purpose, what the motivations were.
+
+## Decision
+
+From now on, all greater or debatable architectural decisions shall be denoted as an ADR within this document, like the "example ADR" you are currently reading. The used template is from [here](https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-by-michael-nygard). Also, questions arising about architecture shall be answered in such an ADR format to procude future references.
+
+## Consequences
+
+* (+) Architecture decisions will become more transparent and understandable.
+* (+) A truth base is defined and referencable.
+* (-) Time needed for documentation.

--- a/docs-architecture/ADR-0002.md
+++ b/docs-architecture/ADR-0002.md
@@ -1,0 +1,22 @@
+# Plugin-based architecture
+
+## Status
+
+Accepted.
+
+## Context
+
+With recurring requirements, a desire grows to avoid repetition and reuse components. This can be implemented with a plugin-based architecture to create new map clients and have the most common features already done.
+
+## Decision
+
+An architecture for the client has been designed that models how we get to re-use functionality without re-writing it while still being open for extensions. The following graphic explains the architecture in further detail.
+
+![polar-2-architecture](https://github.com/Dataport/polar/assets/108349707/70090841-051c-44a7-8fde-2a9252a5d2ef)
+
+## Consequences
+
+* (+) Higher quality of features since multiple parties use them.
+* (+) Implement once, use multiple times.
+* (+) Parts are easier to exchange/develop, and not all clients are required to update immediately.
+* (-) More difficult to understand the codebase.

--- a/docs-architecture/ADR-0002.md
+++ b/docs-architecture/ADR-0002.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted.
+Revoked by ADR 0009.
 
 ## Context
 

--- a/docs-architecture/ADR-0003.md
+++ b/docs-architecture/ADR-0003.md
@@ -1,0 +1,17 @@
+# Error toasts have to be dismissed manually
+
+## Status
+
+Accepted.
+
+## Context
+
+Information relevant for the user is displayed in toasts which close automatically after a custom timeout.
+
+## Decision
+
+A timeout set for toasts that contain error messages will be ignored. Such toasts can only be closed manually by clicking the close button.
+
+## Consequences
+
+* (+) The user is forced to handle error messages and thus is more aware of errors that occur.

--- a/docs-architecture/ADR-0004.md
+++ b/docs-architecture/ADR-0004.md
@@ -1,0 +1,19 @@
+# Vuex mutations have no map side effects
+
+## Status
+
+Accepted.
+
+## Context
+
+OL Map interactions are usually side effects by nature, but are not asynchronous. It was unclear whether such changes belong to actions or mutations.
+
+## Decision
+
+It has been decided that map side effects do not belong to mutations, but to actions.
+
+## Consequences
+
+* (+) Mutations stay clean of side effects.
+* (+) On potential extension of such map calls, asynchronous behaviour may be required; in that case, actions are already the correct position.
+* (-) This restriction must be manually enforced.

--- a/docs-architecture/ADR-0005.md
+++ b/docs-architecture/ADR-0005.md
@@ -1,0 +1,24 @@
+# Difference between actions, utils and lib-packages
+
+## Status
+
+Accepted.
+
+## Context
+
+`actions`, `utils` and `lib`-packages can often consist of very similar code. It was not always clear enough where to place certain functionality, which was ultimately up to each developers own preference.
+
+## Decision
+
+When deciding on where to place code (when writing or refactoring), the following ordered list should be followed:
+
+* Does the functionality also change some part of the state? `action`
+* Should the functionality be usable outside of an integrated client? `action`
+* Does the functionality **not** have state changes, but belongs to a certain `action`? Either locally in the same file as the `action` or in a folder named after the `action` in the path `store/ACTIONNAME`
+* Does the functionality **not** have state changes, but be reusable in the plugin / core? `utils`
+* Should the functionality be reusable for multiple plugins / the core? `lib`-package 
+
+## Consequences
+
+* (+) Gives clarity on where specific code fragments should reside.
+* (-) This restriction must be manually enforced.

--- a/docs-architecture/ADR-0006.md
+++ b/docs-architecture/ADR-0006.md
@@ -1,0 +1,18 @@
+# `console` statement standardization
+
+## Status
+
+Accepted.
+
+## Context
+
+In production environments it may seem unclear if an error or warning message is shown in the console from which part of the application they occurred.
+
+## Decision
+
+All `console.warn` and `console.error` messages have to include the package in which they are invoked.
+
+## Consequences
+
+* (+) Errors and warnings can more easily be tracked back to the place in which they occur.
+* (-) This restriction must be manually enforced.

--- a/docs-architecture/ADR-0007.md
+++ b/docs-architecture/ADR-0007.md
@@ -1,0 +1,19 @@
+# How to expose additional exports of a package
+
+## Status
+
+Accepted.
+
+## Context
+
+There are multiple ways of exposing additional exports of a package. They can either be exposed in the main file or configured as additional export nodes via rollup and the package.json.
+
+## Decision
+
+All exports should be exposed through the main file of the package as additional named exports.
+
+## Consequences
+
+* (+) A package consumer does not need to know additional paths to import.
+* (+) This pattern is established by most major frameworks.
+* (-) This restriction must be manually enforced.

--- a/docs-architecture/ADR-0008.md
+++ b/docs-architecture/ADR-0008.md
@@ -1,0 +1,19 @@
+# Configuration parameters in tables have to be ordered by a) required and b) alphabetically.
+
+## Status
+
+Accepted.
+
+## Context
+
+If a developer is reading the docs, having the configuration parameters order first by required values then alphabetically makes it easier to find relevant parameters.
+
+## Decision
+
+All docs shall be sorted as proposed.
+
+## Consequences
+
+* (+) Better readability of documentation.
+* (+) Clear placement of new parameters.
+* (-) This restriction must be manually enforced.

--- a/docs-architecture/ADR-0009.md
+++ b/docs-architecture/ADR-0009.md
@@ -1,0 +1,23 @@
+# Revoke "ADR 0002: Plugin-based architecture" regarding packaging
+
+## Status
+
+Accepted.
+
+## Context
+
+The current structure uses NPM packages so segment the codebase into reusable parts. These packages have no known outside usage and slow down development in various positions as well as make documentation and changelogs a burden. Instead of a differentiation of core, plugins, and libs, all of these parts shall reside in a single package whilst maintaining the current pluginability feature. This single package shall also offer a default modulith client with all parts readymade for instantiating that can optionally be used.
+
+If accepted, the original ADR shall gain an additional sentence linking to this ADR regarding this future change, as this won't be executed easily, in a short time, or in a single step.
+
+## Decision
+
+We will restructure the architecture as shown in the next big major version.
+
+## Consequences
+
+* (+) Easier maintenance (no superfluous changelogs, easier type access, less boilerplate, faster releases).
+* (+) Easier to understand the codebase.
+* (-) It's not possible to use different versions of packages in the same client, especially old versions.
+  * (+) We never did this anyway and it may have produced complex fix scenarios (LTS for majors?) that no longer may occur.
+* (-) We'll have to introduce technical limitations (architecture checks) regarding imports to prevent the codebase structure from degrading to spaghetti.

--- a/docs-architecture/ADR-0010.md
+++ b/docs-architecture/ADR-0010.md
@@ -1,0 +1,18 @@
+# Manage ADRs with Git
+
+## Status
+
+Accepted.
+
+## Context
+
+Currently, ADRs are managed in a single GitHub wiki page of POLAR.
+
+## Decision
+
+We move the ADRs to the repository in a documentation folder. We write one file per ADR.
+
+## Consequences
+
+- (+) Changes to ADRs can more comfortably be tracked via Git.
+- (o) There is more overhead in creating and updating ADRs, which may lead to writing less of them.


### PR DESCRIPTION
## Summary

The Architecture Decision Records (ADRs), which are currently stored in the GitHub wiki, are moved to the main repository.
The intended workflow for accepted and declined ADR changes is shown in PR ... (follows).

## Instructions for local reproduction and review

*Not applicable*

## Pull Request Checklist (for Assignee)

*Not applicable*

## Relevant tickets, issues, et cetera

- https://github.com/Dataport/polar/wiki/Architecture-Decision-Records-%F0%9F%93%83#2025-07-08-manage-adrs-with-git