### PR TITLE
fix: make snowbox run on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"concurrently": "^9.2.1",
 				"conventional-changelog": "^7.1.1",
 				"conventional-changelog-conventionalcommits": "^9.1.0",
+				"cross-env": "^10.0.0",
 				"es-toolkit": "^1.39.10",
 				"eslint": "^9.34.0",
 				"eslint-config-prettier": "^10.1.8",
@@ -1394,6 +1395,13 @@
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
+		},
+		"node_modules/@epic-web/invariant": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+			"integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@esbuild/aix-ppc64": {
 			"version": "0.25.9",
@@ -6126,6 +6134,24 @@
 				"@types/node": "*",
 				"cosmiconfig": ">=9",
 				"typescript": ">=5"
+			}
+		},
+		"node_modules/cross-env": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+			"integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@epic-web/invariant": "^1.0.0",
+				"cross-spawn": "^7.0.6"
+			},
+			"bin": {
+				"cross-env": "dist/bin/cross-env.js",
+				"cross-env-shell": "dist/bin/cross-env-shell.js"
+			},
+			"engines": {
+				"node": ">=20"
 			}
 		},
 		"node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
 	},
 	"scripts": {
 		"dev": "vite",
-		"snowbox": "VITE_DEV_LANDING=\"examples/snowbox\" vite",
+		"snowbox": "cross-env VITE_DEV_LANDING=examples/snowbox vite",
 		"preview:build": "vite build --watch -c vite.config.preview.ts",
 		"preview:preview": "vite preview -c vite.config.preview.ts",
 		"preview": "conc --kill-others 'npm run build' 'npm run preview:build' 'npm run preview:preview'",
@@ -93,6 +93,7 @@
 		"concurrently": "^9.2.1",
 		"conventional-changelog": "^7.1.1",
 		"conventional-changelog-conventionalcommits": "^9.1.0",
+		"cross-env": "^10.0.0",
 		"es-toolkit": "^1.39.10",
 		"eslint": "^9.34.0",
 		"eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## Summary

Make snowbox work on Windows devices.

## Instructions for local reproduction and review

`npm run snowbox` should now work on Mac/Linux/Windows with `cross-env` introduced to set variables.
