### PR TITLE
fix: interpret crs from non-root return

### DIFF
--- a/packages/clients/snowbox/src/mapConfiguration.ts
+++ b/packages/clients/snowbox/src/mapConfiguration.ts
@@ -96,6 +96,37 @@ export const mapConfiguration = {
         type: 'mpapi',
         url: 'https://geodienste.hamburg.de/HH_WFS_GAGES?service=WFS&request=GetFeature&version=2.0.0',
       },
+      {
+        queryParameters: {
+          typeName: 'Flurstueck',
+          featurePrefix: 'adv',
+          xmlns:
+            'http://repository.gdi-de.org/schemas/adv/produkt/alkis-vereinfacht/2.0',
+          maxFeatures: 20,
+          patterns: [
+            '{{gemarkung}} {{flur}} {{flstnrzae}}/{{flstnrnen}}, {{flstkennz}}',
+            '{{gemarkung}} {{flur}} {{flstnrzae}}, {{flstkennz}}',
+            '{{gemarkung}} {{flstnrzae}}/{{flstnrnen}}, {{flstkennz}}',
+            '{{gemarkung}} {{flstnrzae}}, {{flstkennz}}',
+            '{{gemarkung}} {{flstnrzae}}',
+            '{{flstkennz}}',
+            '{{flstnrzae}}',
+          ],
+          patternKeys: {
+            // only capturing group content is used
+            gemarkung: '([^0-9]+)',
+            flur: '([0-9]+)',
+            flstnrzae: '([0-9]+)',
+            flstnrnen: '([0-9]+)',
+            flstkennz: '([0-9_]+)$',
+          },
+        },
+        placeholder: 'Schiffbek 996',
+        type: 'wfs',
+        groupId: 'wfs_search',
+        label: 'Flurstückssuche',
+        url: 'https://geodienste.hamburg.de/WFS_HH_ALKIS_vereinfacht',
+      },
     ],
     minLength: 3,
     waitMs: 300,

--- a/packages/lib/getFeatures/CHANGELOG.md
+++ b/packages/lib/getFeatures/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Fix: On server returns with the CRS not indicated on the root element, but on its children, the projection is now inferred from those.
+
 ## 3.1.0
 
 - Feature: Add new methods `getVectorFeaturesByBboxRequest` and `getVectorFeaturesByFeatureRequest` that support both WFS and OAF layers.


### PR DESCRIPTION
## Summary

Some WFS do not return the CRS they respond with as part of the FeatureCollection, but merely as part of their children. In such cases, the first-best find from a child is now assumed to be the return's CRS.

## Instructions for local reproduction and review

A fitting search for Hamburg has been added as part of the snowbox to test this.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, ~~Safari~~
