### PR TITLE
refactor: this button needs less js

### DIFF
--- a/src/components/PolarIconButton.ce.vue
+++ b/src/components/PolarIconButton.ce.vue
@@ -1,46 +1,36 @@
 <template>
-	<span
-		v-if="$props.tooltipPosition === 'left' && !hasSmallDisplay"
-		class="polar-tooltip"
-		:style="`opacity: ${hoveredOrFocused ? '1' : '0'}; ${position}`"
-		aria-hidden="true"
-	>
-		{{ hint }}
-	</span>
-	<button
-		ref="button"
-		class="kern-btn kern-btn--secondary polar-icon-button"
-		:class="{
-			'polar-icon-button-active': active,
-			[$props.buttonClass ? $props.buttonClass : '']: true,
-		}"
-		@click="action"
-		@mouseover="hoveredOrFocused = true"
-		@mouseout="hoveredOrFocused = false"
-		@focus="hoveredOrFocused = true"
-		@blur="hoveredOrFocused = false"
-	>
-		<span
-			class="kern-icon"
-			:class="{ [$props.icon]: true, 'polar-icon-button-icon-active': active }"
-			aria-hidden="true"
-		/>
-		<span class="kern-label kern-sr-only">{{ hint }}</span>
-	</button>
-	<span
-		v-if="$props.tooltipPosition === 'right' && !hasSmallDisplay"
-		class="polar-tooltip"
-		:style="`opacity: ${hoveredOrFocused ? '1' : '0'}; ${position}`"
-		aria-hidden="true"
-	>
-		{{ hint }}
-	</span>
+	<div class="polar-icon-button-wrapper">
+		<button
+			ref="button"
+			class="kern-btn kern-btn--secondary polar-icon-button"
+			:class="{ 'polar-icon-button-active': active }"
+			@click="action"
+		>
+			<span
+				class="kern-icon"
+				:class="{
+					[$props.icon]: true,
+					'polar-icon-button-icon-active': active,
+				}"
+				aria-hidden="true"
+			/>
+			<span class="kern-label kern-sr-only">{{ hint }}</span>
+			<span
+				v-if="$props.tooltipPosition && !hasSmallDisplay"
+				class="polar-tooltip"
+				:class="`polar-tooltip-${$props.tooltipPosition}`"
+				aria-hidden="true"
+			>
+				{{ hint }}
+			</span>
+		</button>
+	</div>
 </template>
 
 <script setup lang="ts">
 import { t, type TOptions } from 'i18next'
 import { storeToRefs } from 'pinia'
-import { computed, onMounted, ref, useTemplateRef } from 'vue'
+import { computed } from 'vue'
 import { useCoreStore } from '@/core/stores/export.ts'
 
 /*
@@ -53,28 +43,20 @@ const props = defineProps<{
 	hintNamespace: string
 	icon: string
 	active?: boolean
-	buttonClass?: string
 	hintOptions?: TOptions
 	tooltipPosition?: 'left' | 'right'
 }>()
-
-const hoveredOrFocused = ref(false)
-const position = ref('')
 
 const hint = computed(() =>
 	t(props.hint, { ns: props.hintNamespace, ...props.hintOptions })
 )
 const { hasSmallDisplay } = storeToRefs(useCoreStore())
-
-const button = useTemplateRef<HTMLButtonElement>('button')
-onMounted(() => {
-	// @ts-expect-error | The button is defined after the component has been mounted.
-	position.value = `${props.tooltipPosition === 'right' ? 'left' : 'right'}: ${button.value.offsetWidth + 16}px;`
-})
 </script>
 
 <style scoped>
 .polar-icon-button {
+	position: relative;
+
 	background: var(--kern-color-layout-background-default);
 	box-shadow:
 		0 1px 1px 0 rgba(53, 57, 86, 0.16),
@@ -88,40 +70,49 @@ onMounted(() => {
 		border: solid var(--kern-color-action-on-default);
 		outline: solid var(--kern-color-action-default);
 	}
-}
 
-.polar-icon-button-active {
-	background: var(--kern-color-action-default);
-
-	&:focus,
-	&:hover {
+	.polar-icon-button-active {
 		background: var(--kern-color-action-default);
-		border: solid var(--kern-color-action-on-default);
-		outline: solid var(--kern-color-action-default);
+
+		&:focus,
+		&:hover {
+			background: var(--kern-color-action-default);
+			border: solid var(--kern-color-action-on-default);
+			outline: solid var(--kern-color-action-default);
+		}
 	}
-}
 
-.polar-icon-button-icon-active {
-	background: var(--kern-color-layout-background-default);
-}
+	.polar-icon-button-icon-active {
+		background: var(--kern-color-layout-background-default);
+	}
 
-.polar-tooltip {
-	z-index: 42;
-	display: inline-block;
-	position: absolute;
-	width: auto;
-	margin-top: 8px;
-	padding: 5px 16px;
-	font-family: sans-serif;
-	background: #616161e6;
-	color: #fff;
-	border: 2px solid #fff;
-	border-radius: 4px;
-	font-size: 14px;
-	line-height: 22px;
-	white-space: nowrap;
-	text-transform: none;
-	pointer-events: none;
-	transition: opacity 250ms ease;
+	.polar-tooltip {
+		position: absolute;
+		padding: 5px 16px;
+		font-family: sans-serif;
+		background: #616161e6;
+		color: #fff;
+		border: 2px solid #fff;
+		border-radius: 4px;
+		font-size: 14px;
+		line-height: 22px;
+		white-space: nowrap;
+		pointer-events: none;
+		transition: opacity 250ms ease;
+		opacity: 0;
+
+		&.polar-tooltip-left {
+			right: calc(100% + 0.5rem);
+		}
+
+		&.polar-tooltip-right {
+			left: calc(100% + 0.5rem);
+		}
+	}
+
+	&:hover .polar-tooltip,
+	&:focus-visible .polar-tooltip {
+		opacity: 1;
+	}
 }
 </style>

--- a/src/plugins/fullscreen/components/FullscreenUI.ce.vue
+++ b/src/plugins/fullscreen/components/FullscreenUI.ce.vue
@@ -1,9 +1,7 @@
 <template>
 	<PolarIconButton
 		:action="() => (fullscreenEnabled = !fullscreenEnabled)"
-		:button-class="
-			layout === 'standard' ? 'polar-plugin-fullscreen-standard' : ''
-		"
+		:class="layout === 'standard' ? 'polar-plugin-fullscreen-standard' : ''"
 		hint="button.label"
 		:hint-options="{ context: fullscreenEnabled ? 'off' : 'on' }"
 		:hint-namespace="PluginId"
@@ -25,9 +23,7 @@ const { layout } = storeToRefs(useCoreStore())
 const { fullscreenEnabled } = storeToRefs(useFullscreenStore())
 </script>
 
-<!-- eslint-disable-next-line vue/enforce-style-attribute -->
-<style>
-/* TODO: For some reason, this style doesn't work scoped and with :deep yet. */
+<style scoped>
 .polar-plugin-fullscreen-standard {
 	position: absolute;
 	right: 0;


### PR DESCRIPTION
## Summary

I am touch-a your spaghett.

## Instructions for local reproduction and review

I have altered the way PolarIconButton works to skip some JS that can be modeled with CSS and made sure the component can be styled with external classnames. The bonus `<div>` wrapper is due to the component oftentimes needing to be both `position`ed `absolute` (in the map context) and `relative` (as tooltip anchor).

If you like it, just merge it to your branch as if it was a suggestion. Feel free to modify this branch, too.
