### PR TITLE
fix(core): initialize services earlier to ensure the map has been created for plugins

### DIFF
--- a/examples/iceberg/App.vue
+++ b/examples/iceberg/App.vue
@@ -9,7 +9,7 @@ import { useTemplateRef } from 'vue'
 import { createMap } from '@polar/polar'
 const map = useTemplateRef('map')
 
-createMap(
+await createMap(
 	{
 		layers: [
 			{

--- a/src/core/stores/main.ts
+++ b/src/core/stores/main.ts
@@ -16,7 +16,7 @@ export const useMainStore = defineStore('main', () => {
 	const lightElement = ref<HTMLElement | null>(null)
 	const map = shallowRef({} as Map)
 	const plugins = ref<PluginContainer[]>([])
-	const serviceRegister = ref<string | Record<string, unknown>[]>('')
+	const serviceRegister = ref<Record<string, unknown>[]>([])
 	const shadowRoot = ref<ShadowRoot | null>(null)
 	const zoom = ref(0)
 


### PR DESCRIPTION
## Summary

The map may not have been initialized if the services weren't fully received from a remote source when a plugin has been added.

## Instructions for local reproduction and review

- Change `map` in `mainStore` to `null.`
- Call e.g. `coreStore.map.getLayers()` in `setupPlugin` of `fullscreen` and log the result
- No error should occur