### PR TITLE
style: enforce blank lines before block comments

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,20 @@ const polarConfig = {
 		// POLAR-specific rules
 		'no-warning-comments': 'warn',
 		'no-void': 'off',
+		'@stylistic/lines-around-comment': [
+			'error',
+			{
+				beforeBlockComment: true,
+				allowBlockStart: true,
+				allowObjectStart: true,
+				allowArrayStart: true,
+				allowClassStart: true,
+				allowEnumStart: true,
+				allowInterfaceStart: true,
+				allowModuleStart: true,
+				allowTypeStart: true,
+			},
+		],
 	},
 }
 


### PR DESCRIPTION
## Summary

- Enforce blank lines before TSDoc comments as discussed in Weekly

## Instructions for local reproduction and review

*Stylistic*

## Pull Request Checklist (for Assignee)

*Stylistic*

## Relevant tickets, issues, et cetera

None