### PR TITLE
chore: update @dataport/eslint-config-geodev to v1.0.0-alpha.1 and use TS for eslint config

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -9,7 +9,10 @@ import htmlConfig from '@dataport/eslint-config-geodev/html'
 import prettierConfig from 'eslint-plugin-prettier/recommended'
 import perfectionist from 'eslint-plugin-perfectionist'
 
-const polarConfig = {
+/**
+ * POLAR-specific ESLint configuration
+ */
+const polarConfig = defineConfig({
 	plugins: {
 		perfectionist,
 	},
@@ -23,9 +26,12 @@ const polarConfig = {
 		'no-warning-comments': 'warn',
 		'no-void': 'off',
 	},
-}
+})
 
-const polarTsConfig = {
+/**
+ * POLAR-specific TypeScript ESLint configuration
+ */
+const polarTsConfig = defineConfig({
 	rules: {
 		// Relaxed rules
 		'@typescript-eslint/no-unsafe-argument': 'off',
@@ -50,9 +56,12 @@ const polarTsConfig = {
 			},
 		],
 	},
-}
+})
 
-const polarVueConfig = {
+/**
+ * POLAR-specific Vue ESLint configuration
+ */
+const polarVueConfig = defineConfig({
 	rules: {
 		// POLAR-specific rules
 		'vue/no-empty-component-block': 'error',
@@ -80,9 +89,12 @@ const polarVueConfig = {
 		'vue/require-default-export': 'error',
 		'vue/enforce-style-attribute': ['error', { allow: ['scoped'] }],
 	},
-}
+})
 
-const polarHtmlConfig = {
+/**
+ * POLAR-specific HTML ESLint configuration
+ */
+const polarHtmlConfig = defineConfig({
 	rules: {
 		// POLAR-specific rules
 		'@html-eslint/require-closing-tags': ['error', { selfClosing: 'always' }],
@@ -91,7 +103,7 @@ const polarHtmlConfig = {
 			{ enforceBeforeSelfClose: true },
 		],
 	},
-}
+})
 
 export default defineConfig([
 	{
@@ -127,6 +139,12 @@ export default defineConfig([
 			polarConfig,
 			polarTsConfig,
 		],
+	},
+	{
+		files: ['**/eslint.config.ts'],
+		rules: {
+			'@typescript-eslint/naming-convention': 'off',
+		},
 	},
 	{
 		files: ['**/*.vue'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
 				"@actions/github": "^6.0.1",
 				"@commitlint/cli": "^19.8.1",
 				"@commitlint/config-conventional": "^19.8.1",
-				"@dataport/eslint-config-geodev": "^0.4.0",
+				"@dataport/eslint-config-geodev": "^1.0.0-alpha.1",
 				"@kern-ux/native": "^2.3.0",
 				"@masterportal/masterportalapi": "2.48.0",
 				"@material-symbols/svg-400": "^0.35.0",
@@ -1164,11 +1164,11 @@
 			}
 		},
 		"node_modules/@dataport/eslint-config-geodev": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/@dataport/eslint-config-geodev/-/eslint-config-geodev-0.4.1.tgz",
-			"integrity": "sha512-V0bosGA7uEUGLBzMYcqSGq3b9yX0PofIG4GnL4cScxTDroPZtmu0s7srJrf/V1YuAFx2b55mpYppJYJ6F4G5pA==",
+			"version": "1.0.0-alpha.1",
+			"resolved": "https://registry.npmjs.org/@dataport/eslint-config-geodev/-/eslint-config-geodev-1.0.0-alpha.1.tgz",
+			"integrity": "sha512-pRKDjYKjpZ5MkuCrLx43kJDU2YKMRsLo7rlK4Pkj7OzHwsI1zh1qOE7EmfEY8MzkB6qF5iBm8JJF67qwIaxn6w==",
 			"dev": true,
-			"license": "MIT",
+			"license": "EUPL-1.2",
 			"dependencies": {
 				"@eslint/js": "^9.25.1",
 				"@eslint/json": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"@actions/github": "^6.0.1",
 		"@commitlint/cli": "^19.8.1",
 		"@commitlint/config-conventional": "^19.8.1",
-		"@dataport/eslint-config-geodev": "^0.4.1",
+		"@dataport/eslint-config-geodev": "^1.0.0-alpha.1",
 		"@kern-ux/native": "^2.3.0",
 		"@masterportal/masterportalapi": "2.48.0",
 		"@material-symbols/svg-400": "^0.35.0",


### PR DESCRIPTION
## Summary

- @dataport/eslint-config-geodev is updated to version 1.0.0-alpha.1
- ESLint configuration is written in TypeScript now

## Instructions for local reproduction and review

- npm run lint

## Pull Request Checklist (for Assignee)

-/-

## Relevant tickets, issues, et cetera

-/-