### PR TITLE
refactor: use filled icons

### DIFF
--- a/examples/iceberg/components/IcebergMap.vue
+++ b/examples/iceberg/components/IcebergMap.vue
@@ -1,7 +1,7 @@
 <template>
 	<div :class="$style['action-bar']">
 		<button class="kern-btn kern-btn--secondary" @click="switchLanguage">
-			<span class="kern-icon kern-icon--flag" />
+			<span class="kern-icon kern-icon-fill--flag" />
 			<span class="kern-label">{{
 				language === 'de' ? 'Switch to English' : 'Zu Deutsch wechseln'
 			}}</span>

--- a/examples/snowbox/index.js
+++ b/examples/snowbox/index.js
@@ -247,13 +247,13 @@ addPlugin(
 						id: 'realKewl',
 						locales: [],
 					},
-					icon: 'kern-icon--share',
+					icon: 'kern-icon-fill--share',
 				},
 			],
 			[
 				{
 					plugin: pluginLayerChooser({}),
-					icon: 'kern-icon--layers',
+					icon: 'kern-icon-fill--layers',
 				},
 				{
 					plugin: pluginFullscreen({}),

--- a/src/plugins/iconMenu/types.ts
+++ b/src/plugins/iconMenu/types.ts
@@ -44,7 +44,7 @@ export interface IconMenuPluginOptions extends PluginOptions {
 	 *       },
 	 *       {
 	 *         plugin: PolarPluginDraw({}),
-	 *         icon: 'kern-icon--draw',
+	 *         icon: 'kern-icon-fill--draw',
 	 *         id: 'draw',
 	 *         hint: 'Draw or write something on the map'
 	 *       },

--- a/src/plugins/layerChooser/components/LayerSelection.ce.vue
+++ b/src/plugins/layerChooser/components/LayerSelection.ce.vue
@@ -43,7 +43,10 @@
 							:disabled="disabledMasks[id]"
 							@click="() => updateOpenedOptions(id)"
 						>
-							<span class="kern-icon kern-icon--settings" aria-hidden="true" />
+							<span
+								class="kern-icon kern-icon-fill--settings"
+								aria-hidden="true"
+							/>
 							<span class="kern-label kern-sr-only">
 								{{ $t(($) => $.layerOptions, { ns: PluginId }) }}
 							</span>

--- a/src/plugins/toast/components/ToastUI.ce.vue
+++ b/src/plugins/toast/components/ToastUI.ce.vue
@@ -46,6 +46,7 @@ const toasts = computed(() =>
 						'background-color': getCssColor(toast.theme.color),
 					}
 				: {},
+			// NOTE: The default icons are directly incorporated in KERN.
 			iconClass: toast.theme?.icon || `kern-icon--${kernSeverity}`,
 			text: toast.text,
 			originalToast: toast,


### PR DESCRIPTION
## Summary

As mandated by [KERN](https://www.kern-ux.de/komponenten/icon#beschreibung), all icons that have a `filled`-variant now use that.

## Instructions for local reproduction and review

- `npm i`
- `npm run dev`; both Iceberg and snowbox should still work
