### PR TITLE
test(fullscreen): remove global coreStore mock (side-effects)

### DIFF
--- a/src/plugins/fullscreen/components/FullscreenUI.spec.ts
+++ b/src/plugins/fullscreen/components/FullscreenUI.spec.ts
@@ -33,8 +33,7 @@ const test = _test.extend<{
 })
 /* eslint-enable no-empty-pattern */
 
-// TODO: These tests currently fail as the import of useCoreStore fails. Importing useMainStore yields no problems on the other hand
-test.skip('Component listens to store changes', async ({ wrapper, store }) => {
+test('Component listens to store changes', async ({ wrapper, store }) => {
 	store.fullscreenEnabled = false
 	await nextTick()
 	expect(wrapper.find('.kern-label').text()).toContain(
@@ -48,7 +47,7 @@ test.skip('Component listens to store changes', async ({ wrapper, store }) => {
 	)
 })
 
-test.skip('Component triggers store changes', async ({ wrapper, store }) => {
+test('Component triggers store changes', async ({ wrapper, store }) => {
 	store.fullscreenEnabled = false
 	await nextTick()
 

--- a/src/plugins/fullscreen/store.ts
+++ b/src/plugins/fullscreen/store.ts
@@ -118,11 +118,7 @@ if (import.meta.vitest) {
 	const { expect, test: _test, vi } = import.meta.vitest
 	const { createPinia, setActivePinia } = await import('pinia')
 	const { reactive } = await import('vue')
-
-	const mockedUseCoreStore = vi.hoisted(() => vi.fn())
-	vi.mock('@/core/stores/export', () => ({
-		useCoreStore: mockedUseCoreStore,
-	}))
+	const useCoreStoreFile = await import('@/core/stores/export')
 
 	/* eslint-disable no-empty-pattern */
 	const test = _test.extend<{
@@ -134,7 +130,8 @@ if (import.meta.vitest) {
 				const coreStore = reactive({
 					configuration: { [PluginId]: {} },
 				})
-				mockedUseCoreStore.mockReturnValue(coreStore)
+				// @ts-expect-error | Mocking useCoreStore
+				vi.spyOn(useCoreStoreFile, 'useCoreStore').mockReturnValue(coreStore)
 				await use(coreStore)
 			},
 			{ auto: true },


### PR DESCRIPTION
## Summary

Make coreStore references in tests work again.

## Instructions for local reproduction and review

`npm run test`

## Why does this work?

The old `vi.mock` call wasn't limited to the tests it was supposed to work with.