### PR TITLE
(#397) Fix `npm run preview`

### DIFF
--- a/examples/snowbox/MockAttributions.ce.vue
+++ b/examples/snowbox/MockAttributions.ce.vue
@@ -11,6 +11,6 @@
 	</button>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 // Mock
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
 				"vite-plugin-checker": "^0.12.0",
 				"vite-plugin-commonjs": "^0.10.4",
 				"vite-plugin-dts": "^4.5.4",
-				"vite-plugin-kern-extra-icons": "^0.3.0",
+				"vite-plugin-kern-extra-icons": "^0.4.0",
 				"vite-plugin-vue-devtools": "^8.0.1",
 				"vitest": "^4.0.15",
 				"vue": "^3.5.21",
@@ -15110,9 +15110,9 @@
 			"license": "MIT"
 		},
 		"node_modules/vite-plugin-kern-extra-icons": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/vite-plugin-kern-extra-icons/-/vite-plugin-kern-extra-icons-0.3.0.tgz",
-			"integrity": "sha512-JmESLjaNBLmt/crDi1Tu35NUfWfMjJse0r7gVqIW9WhKAZzHzsT98fwg3KYWfkcAOkflED/Bc6utaCmgmt0WIw==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/vite-plugin-kern-extra-icons/-/vite-plugin-kern-extra-icons-0.4.0.tgz",
+			"integrity": "sha512-PuzlaLj0JDhx9skgpyVPrTTKjNurqodod3E+WVvOqztuN8qWzeNW4MrhjFaFqhr5nsAdk+DMtDWqJWFl5+/oTQ==",
 			"dev": true,
 			"license": "EUPL-1.2",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
 		"vite-plugin-checker": "^0.12.0",
 		"vite-plugin-commonjs": "^0.10.4",
 		"vite-plugin-dts": "^4.5.4",
-		"vite-plugin-kern-extra-icons": "^0.3.0",
+		"vite-plugin-kern-extra-icons": "^0.4.0",
 		"vite-plugin-vue-devtools": "^8.0.1",
 		"vitest": "^4.0.15",
 		"vue": "^3.5.21",

--- a/vite.config.preview.ts
+++ b/vite.config.preview.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vite'
 
 import commonJs from 'vite-plugin-commonjs'
 import vue from '@vitejs/plugin-vue'
+import kernExtraIcons from 'vite-plugin-kern-extra-icons'
 import enrichedConsole from './vitePlugins/enrichedConsole.js'
 
 export default defineConfig({
@@ -17,6 +18,10 @@ export default defineConfig({
 				},
 			},
 		}),
+		kernExtraIcons({
+			cssLayer: 'kern-ux-icons',
+			ignoreFilename: (filename) => !filename.includes('/examples/iceberg/'),
+		}),
 		enrichedConsole(),
 	],
 	build: {
@@ -25,6 +30,7 @@ export default defineConfig({
 			input: {
 				main: resolve(__dirname, 'index.html'),
 				snowbox: resolve(__dirname, 'examples', 'snowbox', 'index.html'),
+				iceberg: resolve(__dirname, 'examples', 'iceberg', 'index.html'),
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

Make `npm run preview` work for iceberg example client.
Also update `vite-plugin-kern-extra-icons` to 0.4.0 which provides `ignoreFilename`.

## Instructions for local reproduction and review

- Run `npm run preview`.
- Verify that http://localhost:1235/examples/iceberg/ works now.
- Verify that http://localhost:1235/examples/snowbox/ works as before, especially that the icon for the mocked component does NOT work there.

## Relevant tickets, issues, et cetera

Closes #397 