### PR TITLE
docs(github-io): add link to POLAR server

### DIFF
--- a/examples/github-io/index.html
+++ b/examples/github-io/index.html
@@ -10,6 +10,7 @@
 		<p>Bleeding-edge POLAP map client, with all the new features.</p>
 		<ul>
 			<li><a href="docs/" target="_blank">Documentation</a></li>
+			<li><a href="https://polar.dataport.de/next/" target="_blank">Live demo</a></li>
 		</ul>
 	</body>
 </html>


### PR DESCRIPTION
## Summary

Add link to POLAR server on GitHub.io "next" page.