### PR TITLE
update jspdf

### DIFF
--- a/__mocks__/jest.setup.js
+++ b/__mocks__/jest.setup.js
@@ -1,5 +1,3 @@
-import 'regenerator-runtime/runtime'
-
 class Worker {
   constructor(stringUrl) {
     this.url = stringUrl

--- a/package-lock.json
+++ b/package-lock.json
@@ -1881,13 +1881,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
-      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -6223,6 +6220,12 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -7288,18 +7291,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/atob": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "atob": "bin/atob.js"
-      },
-      "engines": {
-        "node": ">= 4.5.0"
-      }
-    },
     "node_modules/autolinker": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-4.1.0.tgz",
@@ -7786,18 +7777,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/btoa": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
-      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
-      "license": "(MIT OR Apache-2.0)",
-      "bin": {
-        "btoa": "bin/btoa.js"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -8960,7 +8939,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.4.tgz",
       "integrity": "sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==",
-      "dev": true,
+      "devOptional": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -10392,6 +10371,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
@@ -11600,6 +11590,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -13197,29 +13193,21 @@
       "license": "MIT"
     },
     "node_modules/jspdf": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
-      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-4.0.0.tgz",
+      "integrity": "sha512-w12U97Z6edKd2tXDn3LzTLg7C7QLJlx0BPfM3ecjK2BckUl9/81vZ+r5gK4/3KQdhAcEZhENUxRhtgYBj75MqQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "atob": "^2.1.2",
-        "btoa": "^1.2.1",
+        "@babel/runtime": "^7.28.4",
+        "fast-png": "^6.2.0",
         "fflate": "^0.8.1"
       },
       "optionalDependencies": {
-        "canvg": "^3.0.6",
+        "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^2.5.4",
+        "dompurify": "^3.2.4",
         "html2canvas": "^1.0.0-rc.5"
       }
-    },
-    "node_modules/jspdf/node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true
     },
     "node_modules/jsts": {
       "version": "2.7.1",
@@ -15150,12 +15138,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regenerator-transform": {
       "version": "0.15.2",
@@ -18970,7 +18952,7 @@
       "version": "1.2.2",
       "license": "EUPL-1.2",
       "dependencies": {
-        "jspdf": "^2.5.2"
+        "jspdf": "^4.0.0"
       },
       "devDependencies": {
         "@polar/lib-custom-types": "^2.0.0"

--- a/packages/plugins/Export/CHANGELOG.md
+++ b/packages/plugins/Export/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## unpublished
+
+- Chore: The dependency `jspdf` was updated from `^2.5.2` to `^4.0.0` due to a [security issue](https://github.com/parallax/jsPDF/security/advisories/GHSA-f8cm-6447-x5h2). The security issue did not affect POLAR builds, and no further action is required.
+
 ## 1.2.2
 
 - Chore: Update `@polar/lib-custom-types` to `v2.0.0`.

--- a/packages/plugins/Export/package.json
+++ b/packages/plugins/Export/package.json
@@ -27,7 +27,7 @@
     "CHANGELOG.md"
   ],
   "dependencies": {
-    "jspdf": "^2.5.2"
+    "jspdf": "^4.0.0"
   },
   "peerDependencies": {
     "@repositoryname/vuex-generators": "^1.1.2",


### PR DESCRIPTION
## Summary

Due to [a security vulnerability](https://github.com/parallax/jsPDF/security/advisories/GHSA-f8cm-6447-x5h2), the dependency `jspdf` is updated from `^2.5.2` to `^4.0.0`. Neither of the breaking changes ([3.0.0](https://github.com/parallax/jsPDF/releases/tag/v3.0.0), [4.0.0](https://github.com/parallax/jsPDF/releases/tag/v4.0.0)) is relevant to POLAR. Furthermore, the vulnerability does not affect us, and no further action is required; simply phasing out the old version on an update anywhen, if at all, is sufficient.

During the update, NPM automatically pulled `@babel/runtime` from 7.27.0 to 7.28.4 for uninvestigated reasons. The prior import of `'regenerator-runtime/runtime'` to jest [broke with this update](https://github.com/Dataport/polar/actions/runs/20747495553/job/59568223961). However, the import could simply be removed due to our minimum required version of Node no longer needing it.

## Instructions for local reproduction and review

[snowbox-pdf.patch](https://github.com/user-attachments/files/24452177/snowbox-pdf.patch)

May be tested in the snowbox with this change, which I did. Since the whole operation was rather straightforward, I do not deem repetition on your end necessary.

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome
