### PR TITLE
chore: publish gh-pages to subdirectory main to not mess around

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./pages
+          destination_dir: main


### PR DESCRIPTION
## Summary

This fixes the issue mentioned in https://github.com/Dataport/polar/pull/459#issuecomment-3749411754

## Additional work

If this PR is approved, I'll do the following additional work manually on the gh-pages branch.

- Remove the files from root level.
- Add an index.html manually with the following content:

```html
<!doctype html>
<html>
  <head>
    <meta http-equiv="refresh" content="0; url=./main/" />
  </head>
  <body>
    <p><a href="./main/">Documentation for current stable version</a></p>
  </body>
</html>
```