### PR TITLE
feat: make font family selectable

### DIFF
--- a/examples/snowbox/index.js
+++ b/examples/snowbox/index.js
@@ -62,6 +62,13 @@ const dataportTheme = {
 				default: '0 10px 10px 10px',
 			},
 		},
+		typography: {
+			font: {
+				family: {
+					default: 'Consolas',
+				},
+			},
+		},
 	},
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,7 +9,6 @@
  */
 /* eslint-enable tsdoc/syntax */
 
-import '@kern-ux/native/dist/fonts/fira-sans.css'
 import { defineCustomElement } from 'vue'
 
 import PolarContainer from './components/PolarContainer.ce.vue'

--- a/src/core/types/theme.ts
+++ b/src/core/types/theme.ts
@@ -14,10 +14,22 @@ export interface KernThemeTree {
 /**
  * Describes the theming options of KERN.
  * The exhaustive list of parameters is documented in `@kern-ux/native`.
+ *
+ * **About fonts**
+ *
+ * Please mind that setting a value to `kern.typography.font.family.default`
+ * will stop the client from loading the font `Fira Sans` used in the KERN
+ * design system. 'inherit' will not work as a value due to technical
+ * limitations of the ShadowDOM. To inherit whatever would naturally arrive or
+ * is styled on the host node, use `''` (empty string).
+ * You may also set `"Fira Sans", sans-serif` (the default value) to this
+ * variable in case you already have the font loaded to prevent loading it
+ * twice.
  */
 export interface KernTheme {
 	color: KernThemeTree
 	metric: KernThemeTree
+	typography: KernThemeTree
 }
 
 /**

--- a/src/core/utils/loadKern.ts
+++ b/src/core/utils/loadKern.ts
@@ -37,6 +37,11 @@ export function loadKern(host: ShadowRoot, theme: Partial<KernTheme> = {}) {
 	`)
 	host.adoptedStyleSheets.push(kernSheet)
 
+	// @ts-expect-error | It's fine, we're getting `undefined` for an access on string, too.
+	if (typeof theme.typography?.font?.family?.default !== 'undefined') {
+		void import('@kern-ux/native/dist/fonts/fira-sans.css')
+	}
+
 	const kernTheme = buildKernTheme(theme)
 	host.adoptedStyleSheets.push(kernTheme)
 }


### PR DESCRIPTION
## Summary

Allow `fontFamily` configuration for map client.

## Instructions for local reproduction and review

I've ~~added~~ modified ~~a snippet~~ the dataportTheme in the snowbox that can be uncommented to check the results in it. I suggest trying `'Consolas'`, since it's easily distinguishable, and `''`, since it has a special meaning. When using `''`, set e.g. `font-family: Book Antiqua;` on the POLAR host node in the DOM manipulator to check whether it works as expected.

I'm currently having an issue with vite and couldn't check the build. Please verify that the fonts are bundled separately to the other .css files so that they can only optionally be imported during run-time.

## Pull Request Checklist (for Assignee)

- [ ] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, ~~Safari~~ (Please verify in Safari!)
- [ ] Functionality has been tested on a smartphone
- [ ] Functionality has been tested with 200% screen zoom
- [ ] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [ ] Chrome Lighthouse
  - [ ] Firefox Accessibility

## Relevant tickets, issues, et cetera
