### PR TITLE
ci: prohibit preview fails

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -51,4 +51,4 @@ jobs:
           source-dir: ./.dist.preview/
           preview-branch: gh-pages
           qr-code: true
-          wait-for-pages-deployment: true
+          wait-for-pages-deployment: false


### PR DESCRIPTION
## Summary

Currently, the pipeline for preview fails sometimes; however, this failures are just concurrency effects and no real failures.
This *should* fix this error.

However, the link for the preview is now sometimes posted a minute before it is ready.

## Instructions for local reproduction and review

This PR's workflow should hopefully not fail.
