### PR TITLE
test: force self-closing Vue components

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -16,6 +16,7 @@ import { defineConfig } from 'eslint/config'
 const polarConfig = defineConfig({
 	plugins: {
 		perfectionist,
+		vue,
 	},
 	rules: {
 		'prettier/prettier': 'error',


### PR DESCRIPTION
## Summary

Forgotten self-closing tags as in https://github.com/Dataport/polar/pull/463/changes#diff-41f4432ea012bd214586d379663cca20be9a9f2dd3e8d157f8ede418938e4f1eR18 are prohibited.

## Additional hints

The change from the default options was necessary as this rule otherwise would collide with Prettier.