### PR TITLE
test(snowbox): fix second map creation

### DIFF
--- a/examples/snowbox/index.js
+++ b/examples/snowbox/index.js
@@ -210,8 +210,9 @@ const map = await createMap(
 )
 
 document.getElementById('secondMap').addEventListener('click', async () => {
-	const secondMap = await createMapElement(
+	const secondMap = createMapElement(
 		{
+			startCenter: [573364, 6028874],
 			layers: [
 				{
 					id: basemapId,
@@ -221,7 +222,7 @@ document.getElementById('secondMap').addEventListener('click', async () => {
 				},
 			],
 		},
-		'https://geodienste.hamburg.de/services-internet.json'
+		services
 	)
 	secondMap.classList.add('snowbox')
 	document.getElementById('secondMapContainer').appendChild(secondMap)


### PR DESCRIPTION
## Summary

Currently, creation of a second map in the snowbox is broken.
This is due to a missing configuration parameter.

Additionally, the service register is replaced by the small one to improve performance.

## Instructions for local reproduction and review

- Open the snowbox preview
- Click on `Second map > Add a map client`
- Check that the map actually provides the basemap images