### PR TITLE
docs: expand information on plugin placement in layout standard

### DIFF
--- a/src/core/types/plugin.ts
+++ b/src/core/types/plugin.ts
@@ -43,8 +43,36 @@ import type { NineLayoutTag } from '../utils/NineLayoutTag'
 import type { Locale } from './locales'
 import type { Icon } from './theme'
 
+/**
+ * Generic options for all plugins.
+ *
+ * ## Custom Plugin Positioning ({@link MapConfiguration.layout | Standard Layout})
+ *
+ * When `layout` is set to `'standard'`, a custom plugin can be rendered in one of two ways:
+ *
+ * 1. **As part of the IconMenu**: Set {@link PluginOptions.renderType | renderType}
+ * 		to `'iconMenu'` and configure the plugin in the IconMenu's
+ * 		{@link IconMenuPluginOptions.menus | `menus`} configuration.
+ * 		The IconMenu will handle positioning and rendering the plugin at the designated location.
+ *
+ * 2. **Independent with CSS positioning**: Set {@link PluginOptions.renderType | renderType}
+ * 		to `'independent'` (default). The plugin is responsible for its own positioning
+ * 		using CSS (e.g., `position: absolute`) within the map container.
+ */
 export interface PluginOptions {
+	/**
+	 * Should the component be visible at all.
+	 * Only relevant if {@link MapConfiguration.layout | layout} is set to `'nineRegions'`.
+	 *
+	 * @defaultValue `false`
+	 */
 	displayComponent?: boolean
+
+	/**
+	 * The region where the plugin should be rendered.
+	 * Required if {@link MapConfiguration.layout | layout} is set to `'nineRegions'`,
+	 * ignored otherwise.
+	 */
 	layoutTag?: keyof typeof NineLayoutTag
 }
 
@@ -201,6 +229,8 @@ export interface PluginContainer {
 	 * The component will be rendered by POLAR over the map.
 	 * The position is either to be determined by the plugin if `layout === 'standard'`
 	 * or will be determined by the layout.
+	 *
+	 * @see {@link PluginOptions} for configuration details
 	 */
 	component?: Component
 

--- a/src/core/types/plugin.ts
+++ b/src/core/types/plugin.ts
@@ -46,17 +46,20 @@ import type { Icon } from './theme'
 /**
  * Generic options for all plugins.
  *
- * ## Custom Plugin Positioning ({@link MapConfiguration.layout | Standard Layout})
+ * ## Custom Plugin Positioning
  *
- * When `layout` is set to `'standard'`, a custom plugin can be rendered in one of two ways:
+ * There are two implemented layouting systems in POLAR configured by {@link MapConfiguration.layout}.
  *
- * 1. **As part of the IconMenu**: Set {@link PluginOptions.renderType | renderType}
- * 		to `'iconMenu'` and configure the plugin in the IconMenu's
+ * If `layout` is set to `'nineRegions'` all plugins are placed in a predefined region grid.
+ * Use {@link PluginOptions.displayComponent | displayComponent} to control visibility
+ * and {@link PluginOptions.layoutTag | layoutTag} to specify the target region.
+ *
+ * If `layout` is set to `'standard'`, a plugin can be rendered in one of two ways:
+ * 1. **As part of the IconMenu**: Configure the plugin in the IconMenu's
  * 		{@link IconMenuPluginOptions.menus | `menus`} configuration.
  * 		The IconMenu will handle positioning and rendering the plugin at the designated location.
- *
- * 2. **Independent with CSS positioning**: Set {@link PluginOptions.renderType | renderType}
- * 		to `'independent'` (default). The plugin is responsible for its own positioning
+ * 2. **Independent with CSS positioning**: Directly add the plugin with
+ * 		{@link addPlugin}. The plugin is responsible for its own positioning
  * 		using CSS (e.g., `position: absolute`) within the map container.
  */
 export interface PluginOptions {


### PR DESCRIPTION
## Summary

Add additional information on how (custom) plugins may be played in `layout: 'standard'`.

## Instructions for local reproduction and review

Read it.
