### PR TITLE
feat: update layer type documentation

### DIFF
--- a/src/core/types/layer.ts
+++ b/src/core/types/layer.ts
@@ -25,8 +25,7 @@ export interface LayerConfigurationOptionLayers {
 	title?: boolean | Record<string, string>
 }
 
-// TODO: It should be allowed to set LayerType to a random string to allow for the grouping of different mask layers
-export type LayerType = 'background' | 'mask'
+export type LayerType = 'background' | 'mask' | (string & {})
 
 export interface LayerConfigurationOptions {
 	/**
@@ -73,7 +72,9 @@ export interface LayerConfiguration {
 	name: string
 
 	/**
-	 * Whether the layer is a background layer or a feature layer with specific information.
+	 * Type of layer. Can be background layer, a feature ('mask') layer with
+	 * specific information, or any custom string for grouping different mask layers.
+	 * Custom strings allow for the categorization of layers into arbitrary groups.
 	 */
 	type: LayerType
 

--- a/src/core/types/layer.ts
+++ b/src/core/types/layer.ts
@@ -75,6 +75,16 @@ export interface LayerConfiguration {
 	 * Type of layer. Can be background layer, a feature ('mask') layer with
 	 * specific information, or any custom string for grouping different mask layers.
 	 * Custom strings allow for the categorization of layers into arbitrary groups.
+	 *
+	 * @remarks
+	 * Localization of a custom type is required and can be done by adding the
+	 * following snipped to the localization of a client for the type `dank`.
+	 *
+	 * ```
+	 * layerChooser: {
+	 * 	dankTitle: 'Dank layers',
+	 * },
+	 * ```
 	 */
 	type: LayerType
 


### PR DESCRIPTION
## Summary

Allow layer type to be an arbitrary string so mask layers may be grouped freely.

## Instructions for local reproduction and review

Check in `iceberg` if you now can set the type of a layer to any value.