### PR TITLE
fix(reverseGeocoder): abort ongoing requests if a new reverse geocode request comes in

### DIFF
--- a/src/plugins/reverseGeocoder/store.ts
+++ b/src/plugins/reverseGeocoder/store.ts
@@ -9,7 +9,7 @@ import type { Mock } from 'vitest'
 import { easeOut } from 'ol/easing'
 import { Point } from 'ol/geom'
 import { acceptHMRUpdate, defineStore } from 'pinia'
-import { computed, type Reactive } from 'vue'
+import { computed, type Reactive, ref, toRaw } from 'vue'
 
 import { usePluginStoreWatcher } from '@/composables/usePluginStoreWatcher'
 import { useCoreStore } from '@/core/stores'
@@ -33,6 +33,8 @@ export const useReverseGeocoderStore = defineStore(
 	'plugins/reverseGeocoder',
 	() => {
 		const coreStore = useCoreStore()
+
+		const abortController = ref<AbortController | null>(null)
 
 		const configuration = computed(
 			() => coreStore.configuration[PluginId] as ReverseGeocoderPluginOptions
@@ -68,10 +70,17 @@ export const useReverseGeocoderStore = defineStore(
 
 		async function reverseGeocode(coordinate: [number, number]) {
 			const finish = indicateLoading()
+			if (abortController.value) {
+				abortController.value.abort()
+				abortController.value = null
+			}
+			abortController.value = new AbortController()
+			const signal = toRaw(abortController.value.signal)
 			try {
 				const feature = await reverseGeocodeUtil(
 					configuration.value.url,
-					coordinate
+					coordinate,
+					signal
 				)
 				if (configuration.value.addressTarget) {
 					passFeatureToTarget(configuration.value.addressTarget, feature)
@@ -85,7 +94,9 @@ export const useReverseGeocoderStore = defineStore(
 				}
 				return feature
 			} catch (error) {
-				console.error('Reverse geocoding failed:', error)
+				if (!signal.aborted) {
+					console.error('Reverse geocoding failed:', error)
+				}
 				return null
 			} finally {
 				finish()
@@ -100,6 +111,9 @@ export const useReverseGeocoderStore = defineStore(
 			 * @returns A promise that resolves to the reverse geocoded feature or null.
 			 */
 			reverseGeocode,
+
+			/** @internal */
+			abortController,
 
 			/** @internal */
 			setupPlugin,
@@ -188,6 +202,7 @@ if (import.meta.vitest) {
 	test('detects changes in coordinate sources', async ({
 		reverseGeocodeUtil,
 		coreStore,
+		store,
 	}) => {
 		const pluginStore = coreStore.pluginStores as {
 			pins: {
@@ -198,7 +213,8 @@ if (import.meta.vitest) {
 		await new Promise((resolve) => setTimeout(resolve))
 		expect(reverseGeocodeUtil).toHaveBeenCalledWith(
 			'https://wps.example',
-			[1, 2]
+			[1, 2],
+			store.abortController?.signal
 		)
 	})
 

--- a/src/plugins/reverseGeocoder/utils/reverseGeocode.ts
+++ b/src/plugins/reverseGeocoder/utils/reverseGeocode.ts
@@ -32,13 +32,21 @@ const parser = new Parser({
 	tagNameProcessors: [processors.stripPrefix],
 })
 
+let abortController: AbortController | null = null
+
 export async function reverseGeocode(
 	url: string,
 	coordinate: [number, number]
 ): Promise<ReverseGeocoderFeature> {
+	if (abortController) {
+		abortController.abort()
+		abortController = null
+	}
+	abortController = new AbortController()
 	const response = await fetch(url, {
 		method: 'POST',
 		body: buildPostBody(coordinate),
+		signal: abortController.signal,
 	})
 
 	const parsedBody = await parser.parseStringPromise(await response.text())
@@ -142,6 +150,7 @@ if (import.meta.vitest) {
 		expect(fetchMock).toHaveBeenCalledWith(testUrl, {
 			method: 'POST',
 			body: buildPostBody(testCoordinates),
+			signal: abortController?.signal,
 		})
 
 		expect(feature).toEqual<ReverseGeocoderFeature>({

--- a/src/plugins/reverseGeocoder/utils/reverseGeocode.ts
+++ b/src/plugins/reverseGeocoder/utils/reverseGeocode.ts
@@ -32,21 +32,15 @@ const parser = new Parser({
 	tagNameProcessors: [processors.stripPrefix],
 })
 
-let abortController: AbortController | null = null
-
 export async function reverseGeocode(
 	url: string,
-	coordinate: [number, number]
+	coordinate: [number, number],
+	signal: AbortSignal
 ): Promise<ReverseGeocoderFeature> {
-	if (abortController) {
-		abortController.abort()
-		abortController = null
-	}
-	abortController = new AbortController()
 	const response = await fetch(url, {
 		method: 'POST',
 		body: buildPostBody(coordinate),
-		signal: abortController.signal,
+		signal,
 	})
 
 	const parsedBody = await parser.parseStringPromise(await response.text())
@@ -143,14 +137,18 @@ if (import.meta.vitest) {
 		const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValueOnce({
 			text: () => Promise.resolve(testResponse),
 		} as Response)
-
-		const feature = await reverseGeocode(testUrl, testCoordinates)
+		const abortController = new AbortController()
+		const feature = await reverseGeocode(
+			testUrl,
+			testCoordinates,
+			abortController.signal
+		)
 
 		expect(fetchMock).toHaveBeenCalledOnce()
 		expect(fetchMock).toHaveBeenCalledWith(testUrl, {
 			method: 'POST',
 			body: buildPostBody(testCoordinates),
-			signal: abortController?.signal,
+			signal: abortController.signal,
 		})
 
 		expect(feature).toEqual<ReverseGeocoderFeature>({


### PR DESCRIPTION
## Summary

As the title states, reverse geocoding is now being aborted once a new request comes in. If this were not to be added, I could e.g. drag the pin around a few times and the map would keep centering on ALL position.

## Instructions for local reproduction and review

Drag the pin around a few times in `iceberg`. It should now only center the map on the last position.
