### PR TITLE
fix(core): fix width and height of map overlay

### DIFF
--- a/src/core/components/PolarContainer.ce.vue
+++ b/src/core/components/PolarContainer.ce.vue
@@ -102,7 +102,7 @@ function updateListeners() {
 		!hasWindowSize.value &&
 		polarMapContainer.value &&
 		polarMapContainer.value.el &&
-		mainStore.hasSmallDisplay
+		hasSmallDisplay.value
 	) {
 		hammer?.destroy()
 		hammer = new Hammer(polarMapContainer.value.el).on('pan', (e) => {

--- a/src/core/components/PolarContainer.ce.vue
+++ b/src/core/components/PolarContainer.ce.vue
@@ -5,8 +5,9 @@
 		:lang="language"
 		:data-kern-theme="mainStore.colorScheme"
 	>
+		<PolarMapOverlay ref="polar-map-overlay" />
 		<div class="polar-map-layer">
-			<PolarMap />
+			<PolarMap ref="polar-map-container" @wheel="wheelEffect" />
 		</div>
 		<div class="polar-ui-layer">
 			<div v-if="!hasWindowSize" class="polar-shadow" aria-hidden="true" />
@@ -21,9 +22,11 @@
 
 <script setup lang="ts">
 import { toMerged } from 'es-toolkit'
-import i18next from 'i18next'
+import Hammer from 'hammerjs'
+import i18next, { t } from 'i18next'
 import { disposePinia, getActivePinia, type Pinia, storeToRefs } from 'pinia'
 import {
+	computed,
 	getCurrentInstance,
 	onBeforeUnmount,
 	onMounted,
@@ -36,6 +39,7 @@ import {
 
 import type { MapConfiguration, MasterportalApiServiceRegister } from '../types'
 
+import { useT } from '../composables/useT'
 import { useCoreStore } from '../stores'
 import { useMainStore } from '../stores/main'
 import { useMoveHandleStore } from '../stores/moveHandle'
@@ -43,6 +47,7 @@ import { loadKern } from '../utils/loadKern'
 import { mapZoomOffset } from '../utils/mapZoomOffset'
 import MoveHandle from './MoveHandle.ce.vue'
 import PolarMap from './PolarMap.ce.vue'
+import PolarMapOverlay from './PolarMapOverlay.ce.vue'
 import PolarUI from './PolarUI.ce.vue'
 
 defineOptions({
@@ -58,8 +63,58 @@ defineExpose<{
 	store: ReturnType<typeof useCoreStore>
 }>()
 
+const polarMapContainer = useTemplateRef<HTMLDivElement>('polar-map-container')
+const overlay = useTemplateRef<typeof PolarMapOverlay>('polar-map-overlay')
+
+const isMacOS = navigator.userAgent.indexOf('Mac') !== -1
+const noCommandOnZoom = useT(() =>
+	t(($) => $.overlay.noCommandOnZoom, { ns: 'core' })
+)
+const noControlOnZoom = useT(() =>
+	t(($) => $.overlay.noControlOnZoom, { ns: 'core' })
+)
+
+function wheelEffect(event: WheelEvent) {
+	if (hasWindowSize.value || !overlay.value) {
+		return
+	}
+	const condition = computed(() => !hasWindowSize.value)
+	if (isMacOS && !event.metaKey) {
+		overlay.value.show(noCommandOnZoom, condition)
+	} else if (!isMacOS && !event.ctrlKey) {
+		overlay.value.show(noControlOnZoom, condition)
+	}
+}
+
+const oneFingerPan = useT(() =>
+	t(($) => $.overlay.oneFingerPan, { ns: 'core' })
+)
+let hammer: { destroy: () => void } | null = null
+function updateListeners() {
+	if (
+		!hasWindowSize.value &&
+		polarMapContainer.value &&
+		mainStore.hasSmallDisplay
+	) {
+		hammer?.destroy()
+		hammer = new Hammer(polarMapContainer.value).on('pan', (e) => {
+			if (
+				overlay.value &&
+				e.maxPointers === 1 &&
+				!mainStore.map
+					.getInteractions()
+					.getArray()
+					.some((interaction) => interaction.get('_isPolarDragLikeInteraction'))
+			) {
+				overlay.value.show(oneFingerPan)
+			}
+		})
+	}
+}
+
 const mainStore = useMainStore()
-const { hasSmallWidth, hasWindowSize, language } = storeToRefs(mainStore)
+const { hasSmallDisplay, hasSmallWidth, hasWindowSize, language } =
+	storeToRefs(mainStore)
 
 mainStore.configuration = toMerged(
 	mainStore.configuration,
@@ -109,6 +164,8 @@ watch(
 		await i18next.changeLanguage(newLanguage)
 	}
 )
+watch(hasWindowSize, updateListeners)
+watch(hasSmallDisplay, updateListeners)
 
 const polarWrapper = useTemplateRef<HTMLDivElement>('polar-wrapper')
 
@@ -145,6 +202,9 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+	hammer?.destroy()
+	hammer = null
+
 	if (resizeObserver instanceof ResizeObserver) {
 		resizeObserver.unobserve(polarWrapper.value as Element)
 		resizeObserver = null

--- a/src/core/components/PolarContainer.ce.vue
+++ b/src/core/components/PolarContainer.ce.vue
@@ -7,7 +7,11 @@
 	>
 		<PolarMapOverlay ref="polar-map-overlay" />
 		<div class="polar-map-layer">
-			<PolarMap ref="polar-map-container" @wheel="wheelEffect" />
+			<PolarMap
+				ref="polar-map-container"
+				@wheel="wheelEffect"
+				@update-listeners="updateListeners"
+			/>
 		</div>
 		<div class="polar-ui-layer">
 			<div v-if="!hasWindowSize" class="polar-shadow" aria-hidden="true" />
@@ -63,8 +67,11 @@ defineExpose<{
 	store: ReturnType<typeof useCoreStore>
 }>()
 
-const polarMapContainer = useTemplateRef<HTMLDivElement>('polar-map-container')
-const overlay = useTemplateRef<typeof PolarMapOverlay>('polar-map-overlay')
+const polarMapContainer = useTemplateRef<InstanceType<typeof PolarMap>>(
+	'polar-map-container'
+)
+const overlay =
+	useTemplateRef<InstanceType<typeof PolarMapOverlay>>('polar-map-overlay')
 
 const isMacOS = navigator.userAgent.indexOf('Mac') !== -1
 const noCommandOnZoom = useT(() =>
@@ -94,10 +101,11 @@ function updateListeners() {
 	if (
 		!hasWindowSize.value &&
 		polarMapContainer.value &&
+		polarMapContainer.value.el &&
 		mainStore.hasSmallDisplay
 	) {
 		hammer?.destroy()
-		hammer = new Hammer(polarMapContainer.value).on('pan', (e) => {
+		hammer = new Hammer(polarMapContainer.value.el).on('pan', (e) => {
 			if (
 				overlay.value &&
 				e.maxPointers === 1 &&
@@ -164,8 +172,6 @@ watch(
 		await i18next.changeLanguage(newLanguage)
 	}
 )
-watch(hasWindowSize, updateListeners)
-watch(hasSmallDisplay, updateListeners)
 
 const polarWrapper = useTemplateRef<HTMLDivElement>('polar-wrapper')
 

--- a/src/core/components/PolarContainer.ce.vue
+++ b/src/core/components/PolarContainer.ce.vue
@@ -98,13 +98,14 @@ const oneFingerPan = useT(() =>
 )
 let hammer: { destroy: () => void } | null = null
 function updateListeners() {
+	hammer?.destroy()
+	hammer = null
 	if (
 		!hasWindowSize.value &&
 		polarMapContainer.value &&
 		polarMapContainer.value.el &&
 		hasSmallDisplay.value
 	) {
-		hammer?.destroy()
 		hammer = new Hammer(polarMapContainer.value.el).on('pan', (e) => {
 			if (
 				overlay.value &&

--- a/src/core/components/PolarMap.ce.vue
+++ b/src/core/components/PolarMap.ce.vue
@@ -156,7 +156,7 @@ function updateListeners() {
 			if (
 				overlay.value &&
 				e.maxPointers === 1 &&
-				mainStore.map
+				!mainStore.map
 					.getInteractions()
 					.getArray()
 					.some((interaction) => interaction.get('_isPolarDragLikeInteraction'))

--- a/src/core/components/PolarMap.ce.vue
+++ b/src/core/components/PolarMap.ce.vue
@@ -168,6 +168,7 @@ function updateListeners() {
 }
 
 watch(hasWindowSize, updateListeners)
+watch(hasSmallDisplay, updateListeners)
 </script>
 
 <!-- eslint-disable-next-line vue/enforce-style-attribute -->

--- a/src/core/components/PolarMap.ce.vue
+++ b/src/core/components/PolarMap.ce.vue
@@ -1,12 +1,11 @@
 <template>
-	<PolarMapOverlay ref="polar-map-overlay" />
 	<div
 		ref="polar-map-container"
 		class="polar-map"
 		tabindex="0"
 		role="region"
 		:aria-label="$t(($) => $.canvas.label, { ns: 'core' })"
-		@wheel="wheelEffect"
+		@wheel="(e) => $emit('wheel', e)"
 	/>
 </template>
 
@@ -14,34 +13,24 @@
 import type { Map } from 'ol'
 
 import api from '@masterportal/masterportalapi/src/maps/api'
-import Hammer from 'hammerjs'
-import { t } from 'i18next'
 import { easeOut } from 'ol/easing'
 import { defaults } from 'ol/interaction'
 import { storeToRefs } from 'pinia'
-import {
-	computed,
-	markRaw,
-	onBeforeUnmount,
-	onMounted,
-	useTemplateRef,
-	watch,
-} from 'vue'
+import { markRaw, onBeforeUnmount, onMounted, useTemplateRef, watch } from 'vue'
 
-import { useT } from '../composables/useT'
 import { useMainStore } from '../stores/main'
 import { checkServiceAvailability } from '../utils/checkServiceAvailability'
 import { createKeyboardInteractions } from '../utils/interactions'
 import { setupMarkers } from '../utils/map/setupMarkers'
 import { setupStyling } from '../utils/map/setupStyling'
 import { updateDragAndZoomInteractions } from '../utils/map/updateDragAndZoomInteractions'
-import PolarMapOverlay from './PolarMapOverlay.ce.vue'
+
+const emit = defineEmits(['updateListeners', 'wheel'])
 
 const mainStore = useMainStore()
 const { hasWindowSize, hasSmallDisplay, center, zoom } = storeToRefs(mainStore)
 
 const polarMapContainer = useTemplateRef<HTMLDivElement>('polar-map-container')
-const overlay = useTemplateRef<typeof PolarMapOverlay>('polar-map-overlay')
 
 function onMove() {
 	center.value = mainStore.map.getView().getCenter() || center.value
@@ -81,7 +70,7 @@ function createMap() {
 	createKeyboardInteractions().forEach((interaction) => {
 		mainStore.map.addInteraction(interaction)
 	})
-	updateListeners()
+	emit('updateListeners')
 }
 
 // NOTE: Updates can happen if a user resizes the window or the fullscreen plugin is used.
@@ -102,25 +91,6 @@ watch(zoom, (zoom) => {
 	mainStore.map.getView().setZoom(zoom)
 })
 
-const isMacOS = navigator.userAgent.indexOf('Mac') !== -1
-const noCommandOnZoom = useT(() =>
-	t(($) => $.overlay.noCommandOnZoom, { ns: 'core' })
-)
-const noControlOnZoom = useT(() =>
-	t(($) => $.overlay.noControlOnZoom, { ns: 'core' })
-)
-function wheelEffect(event: WheelEvent) {
-	if (hasWindowSize.value || !overlay.value) {
-		return
-	}
-	const condition = computed(() => !hasWindowSize.value)
-	if (isMacOS && !event.metaKey) {
-		overlay.value.show(noCommandOnZoom, condition)
-	} else if (!isMacOS && !event.ctrlKey) {
-		overlay.value.show(noControlOnZoom, condition)
-	}
-}
-
 onMounted(async () => {
 	createMap()
 	if (mainStore.configuration.checkServiceAvailability) {
@@ -137,38 +107,7 @@ onMounted(async () => {
 })
 onBeforeUnmount(() => {
 	mainStore.map.un('moveend', onMove)
-	hammer?.destroy()
-	hammer = null
 })
-
-const oneFingerPan = useT(() =>
-	t(($) => $.overlay.oneFingerPan, { ns: 'core' })
-)
-let hammer: { destroy: () => void } | null = null
-function updateListeners() {
-	if (
-		!hasWindowSize.value &&
-		polarMapContainer.value &&
-		mainStore.hasSmallDisplay
-	) {
-		hammer?.destroy()
-		hammer = new Hammer(polarMapContainer.value).on('pan', (e) => {
-			if (
-				overlay.value &&
-				e.maxPointers === 1 &&
-				!mainStore.map
-					.getInteractions()
-					.getArray()
-					.some((interaction) => interaction.get('_isPolarDragLikeInteraction'))
-			) {
-				overlay.value.show(oneFingerPan)
-			}
-		})
-	}
-}
-
-watch(hasWindowSize, updateListeners)
-watch(hasSmallDisplay, updateListeners)
 </script>
 
 <!-- eslint-disable-next-line vue/enforce-style-attribute -->

--- a/src/core/components/PolarMap.ce.vue
+++ b/src/core/components/PolarMap.ce.vue
@@ -25,12 +25,13 @@ import { setupMarkers } from '../utils/map/setupMarkers'
 import { setupStyling } from '../utils/map/setupStyling'
 import { updateDragAndZoomInteractions } from '../utils/map/updateDragAndZoomInteractions'
 
+const polarMapContainer = useTemplateRef<HTMLDivElement>('polar-map-container')
+defineExpose({ el: polarMapContainer })
+
 const emit = defineEmits(['updateListeners', 'wheel'])
 
 const mainStore = useMainStore()
 const { hasWindowSize, hasSmallDisplay, center, zoom } = storeToRefs(mainStore)
-
-const polarMapContainer = useTemplateRef<HTMLDivElement>('polar-map-container')
 
 function onMove() {
 	center.value = mainStore.map.getView().getCenter() || center.value
@@ -75,8 +76,9 @@ function createMap() {
 
 // NOTE: Updates can happen if a user resizes the window or the fullscreen plugin is used.
 //       Added as a watcher to trigger the update at the correct time.
-watch(hasWindowSize, (value) => {
-	updateDragAndZoomInteractions(mainStore.map, value, hasSmallDisplay.value)
+watch([hasWindowSize, hasSmallDisplay], ([windowSize, smallDisplay]) => {
+	updateDragAndZoomInteractions(mainStore.map, windowSize, smallDisplay)
+	emit('updateListeners')
 })
 
 watch(center, (center) => {

--- a/src/core/components/PolarMapOverlay.ce.vue
+++ b/src/core/components/PolarMapOverlay.ce.vue
@@ -69,8 +69,8 @@ defineExpose({
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	width: inherit;
-	height: inherit;
+	width: 100%;
+	height: 100%;
 	z-index: 42;
 	font-size: var(--kern-typography-font-size-static-large);
 	text-align: center;

--- a/src/core/components/PolarMapOverlay.ce.vue
+++ b/src/core/components/PolarMapOverlay.ce.vue
@@ -77,6 +77,7 @@ defineExpose({
 	color: white;
 	background-color: rgba(0, 0, 0, 0.45);
 	pointer-events: none;
+	border-radius: var(--kern-metric-border-radius-large);
 }
 
 .fade-enter-active,


### PR DESCRIPTION
## Summary

Update the width and the height of the map overlay. This was broken after #545.
Note that the overlay now is placed below the interface elements. I think this is quite nice. If you disagree, I'll change it back to the previous implementation.

## Instructions for local reproduction and review

`npm run snowbox` and try scrolling via mousewheel.
