### PR TITLE
chore: update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,7 @@ updates:
     directory: /
     target-branch: next
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 20
     cooldown:
       default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,27 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    target-branch: "next"
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: next
     schedule:
-      interval: "daily"
+      interval: weekly
+    open-pull-requests-limit: 20
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: chore
+      include: scope
+
+  - package-ecosystem: npm
+    directory: /
+    target-branch: next
+    schedule:
+      interval: daily
     open-pull-requests-limit: 20
     cooldown:
       default-days: 3
+    commit-message:
+      prefix: chore
+      include: scope
+    versioning-strategy: increase


### PR DESCRIPTION
## Summary

Updates the dependabot configuration to also update github actions.

## Instructions for local reproduction and review

Take a look at the pipeline (which currently breaks because [diplanung-style](https://www.npmjs.com/package/diplanung-style) is gone from npm; it can somehow still be found locally)

## Relevant tickets, issues, et cetera

#694 has the same changes
