### PR TITLE
refactor: update kern components to use slots in favour of props

### DIFF
--- a/examples/github-io/components/TheBadge.vue
+++ b/examples/github-io/components/TheBadge.vue
@@ -1,6 +1,6 @@
 <template>
-	<span :class="`kern-badge kern-badge--${$props.color}`">
-		<span :class="`kern-label kern-label--small kern-label--${$props.color}`">
+	<span :class="`kern-badge kern-badge--${color}`">
+		<span :class="`kern-label kern-label--small kern-label--${color}`">
 			<slot />
 		</span>
 	</span>

--- a/src/components/PolarInput.ce.vue
+++ b/src/components/PolarInput.ce.vue
@@ -13,7 +13,7 @@
 			class="polar-input kern-label"
 			:for="`polar-${type}-${value}-${idSuffix}`"
 		>
-			{{ label }}
+			<slot />
 		</label>
 	</div>
 </template>
@@ -23,7 +23,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const props = defineProps<{
 	idSuffix: string
-	label: string
 	type: T
 	value: string
 	disabled?: boolean

--- a/src/components/kern/KernBlockButton.ce.vue
+++ b/src/components/kern/KernBlockButton.ce.vue
@@ -1,28 +1,22 @@
 <template>
 	<button
 		class="kern-btn kern-btn--block kern-btn--tertiary"
-		@click="emit('click')"
+		@click="$emit('click')"
 	>
 		<span
-			v-if="props.icon"
-			:class="{ 'kern-icon': true, [props.icon]: true }"
+			v-if="$props.icon"
+			:class="`kern-icon ${$props.icon}`"
 			aria-hidden="true"
 		/>
-		<span class="kern-label">{{ props.label }}</span>
+		<span class="kern-label"><slot /></span>
 	</button>
 </template>
 
 <script setup lang="ts">
 import type { Icon } from '@/core'
 
-const props = defineProps<{
-	icon?: Icon | false
-	label: string
-}>()
-
-const emit = defineEmits<{
-	click: []
-}>()
+defineProps<{ icon?: Icon }>()
+defineEmits<{ click: [] }>()
 </script>
 
 <style scoped>

--- a/src/components/kern/KernBlockButton.ce.vue
+++ b/src/components/kern/KernBlockButton.ce.vue
@@ -3,7 +3,7 @@
 		class="kern-btn kern-btn--block kern-btn--tertiary"
 		@click="$emit('click')"
 	>
-		<span v-if="icon" :class="`kern-icon ${icon}`" aria-hidden="true" />
+		<span v-if="icon" class="kern-icon" :class="icon" aria-hidden="true" />
 		<span class="kern-label"><slot /></span>
 	</button>
 </template>

--- a/src/components/kern/KernBlockButton.ce.vue
+++ b/src/components/kern/KernBlockButton.ce.vue
@@ -3,11 +3,7 @@
 		class="kern-btn kern-btn--block kern-btn--tertiary"
 		@click="$emit('click')"
 	>
-		<span
-			v-if="$props.icon"
-			:class="`kern-icon ${$props.icon}`"
-			aria-hidden="true"
-		/>
+		<span v-if="icon" :class="`kern-icon ${icon}`" aria-hidden="true" />
 		<span class="kern-label"><slot /></span>
 	</button>
 </template>

--- a/src/components/kern/KernBlockButtonCheckbox.ce.vue
+++ b/src/components/kern/KernBlockButtonCheckbox.ce.vue
@@ -8,11 +8,11 @@
 	/>
 	<label :for="id" class="kern-btn kern-btn--block kern-btn--tertiary">
 		<span
-			v-if="props.icon"
-			:class="{ 'kern-icon': true, [props.icon]: true }"
+			v-if="$props.icon"
+			:class="`kern-icon ${$props.icon}`"
 			aria-hidden="true"
 		/>
-		<span class="kern-label">{{ props.label }}</span>
+		<span class="kern-label"><slot /></span>
 	</label>
 </template>
 
@@ -21,10 +21,7 @@ import { useId } from 'vue'
 
 import type { Icon } from '@/core'
 
-const props = defineProps<{
-	icon?: Icon | false
-	label: string
-}>()
+defineProps<{ icon?: Icon }>()
 
 const model = defineModel<boolean>({ required: true })
 

--- a/src/components/kern/KernBlockButtonCheckbox.ce.vue
+++ b/src/components/kern/KernBlockButtonCheckbox.ce.vue
@@ -7,7 +7,7 @@
 		@focus="scrollVisible($event)"
 	/>
 	<label :for="id" class="kern-btn kern-btn--block kern-btn--tertiary">
-		<span v-if="icon" :class="`kern-icon ${icon}`" aria-hidden="true" />
+		<span v-if="icon" class="kern-icon" :class="icon" aria-hidden="true" />
 		<span class="kern-label"><slot /></span>
 	</label>
 </template>

--- a/src/components/kern/KernBlockButtonCheckbox.ce.vue
+++ b/src/components/kern/KernBlockButtonCheckbox.ce.vue
@@ -7,11 +7,7 @@
 		@focus="scrollVisible($event)"
 	/>
 	<label :for="id" class="kern-btn kern-btn--block kern-btn--tertiary">
-		<span
-			v-if="$props.icon"
-			:class="`kern-icon ${$props.icon}`"
-			aria-hidden="true"
-		/>
+		<span v-if="icon" :class="`kern-icon ${icon}`" aria-hidden="true" />
 		<span class="kern-label"><slot /></span>
 	</label>
 </template>

--- a/src/components/kern/KernBlockButtonRadioGroup.ce.vue
+++ b/src/components/kern/KernBlockButtonRadioGroup.ce.vue
@@ -19,7 +19,8 @@
 			>
 				<span
 					v-if="item.icon"
-					:class="`kern-icon ${item.icon}`"
+					class="kern-icon"
+					:class="item.icon"
 					aria-hidden="true"
 				/>
 				<span class="kern-label">{{ item.label }}</span>

--- a/src/components/kern/KernBlockButtonRadioGroup.ce.vue
+++ b/src/components/kern/KernBlockButtonRadioGroup.ce.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="radiogroup" role="radiogroup">
-		<template v-for="(item, idx) of props.items" :key="idx">
+		<template v-for="(item, idx) of $props.items" :key="idx">
 			<span
 				ref="radios"
 				role="radio"
@@ -19,7 +19,7 @@
 			>
 				<span
 					v-if="item.icon"
-					:class="{ 'kern-icon': true, [item.icon]: true }"
+					:class="`kern-icon ${item.icon}`"
 					aria-hidden="true"
 				/>
 				<span class="kern-label">{{ item.label }}</span>
@@ -33,11 +33,11 @@ import { useId, useTemplateRef } from 'vue'
 
 import type { Icon } from '@/core'
 
-const props = defineProps<{
+defineProps<{
 	items: {
 		value: string
 		label: string
-		icon?: Icon | false
+		icon?: Icon
 	}[]
 }>()
 

--- a/src/components/kern/KernBlockButtonRadioGroup.ce.vue
+++ b/src/components/kern/KernBlockButtonRadioGroup.ce.vue
@@ -1,6 +1,6 @@
 <template>
 	<div class="radiogroup" role="radiogroup">
-		<template v-for="(item, idx) of $props.items" :key="idx">
+		<template v-for="(item, idx) of items" :key="idx">
 			<span
 				ref="radios"
 				role="radio"

--- a/src/components/kern/KernCheckbox.ce.vue
+++ b/src/components/kern/KernCheckbox.ce.vue
@@ -7,21 +7,12 @@
 			type="checkbox"
 			@keydown.prevent.enter="model = !model"
 		/>
-		<label :for="id" class="kern-label">
-			{{ props.label }}
-		</label>
+		<label :for="id" class="kern-label"><slot /></label>
 	</div>
 </template>
 
 <script setup lang="ts">
 import { useId } from 'vue'
-
-import type { Icon } from '@/core'
-
-const props = defineProps<{
-	icon?: Icon | false
-	label: string
-}>()
 
 const model = defineModel<boolean>({ required: true })
 

--- a/src/components/kern/KernDatePicker.ce.vue
+++ b/src/components/kern/KernDatePicker.ce.vue
@@ -3,8 +3,8 @@
 		v-model="inputModel"
 		type="date"
 		class="kern-form-input__input"
-		:min="dateToString(props.min ?? null)"
-		:max="dateToString(props.max ?? null)"
+		:min="dateToString($props.min ?? null)"
+		:max="dateToString($props.max ?? null)"
 	/>
 </template>
 
@@ -13,7 +13,7 @@ import { computed } from 'vue'
 
 import { dateToString, stringToDate } from '@/lib/dateUtils'
 
-const props = defineProps<{
+defineProps<{
 	min?: Date
 	max?: Date
 }>()

--- a/src/components/kern/KernDatePicker.ce.vue
+++ b/src/components/kern/KernDatePicker.ce.vue
@@ -3,8 +3,8 @@
 		v-model="inputModel"
 		type="date"
 		class="kern-form-input__input"
-		:min="dateToString($props.min ?? null)"
-		:max="dateToString($props.max ?? null)"
+		:min="dateToString(min ?? null)"
+		:max="dateToString(max ?? null)"
 	/>
 </template>
 

--- a/src/components/kern/KernDateRangePicker.ce.vue
+++ b/src/components/kern/KernDateRangePicker.ce.vue
@@ -1,15 +1,15 @@
 <template>
 	<div class="range-picker">
-		<KernDatePicker v-model="start" v-bind="$props" />
+		<KernDatePicker v-model="start" v-bind="props" />
 		–
-		<KernDatePicker v-model="end" v-bind="$props" />
+		<KernDatePicker v-model="end" v-bind="props" />
 	</div>
 </template>
 
 <script setup lang="ts">
 import KernDatePicker from './KernDatePicker.ce.vue'
 
-defineProps<{
+const props = defineProps<{
 	min?: Date
 	max?: Date
 }>()

--- a/src/components/kern/KernDateRangePicker.ce.vue
+++ b/src/components/kern/KernDateRangePicker.ce.vue
@@ -1,15 +1,15 @@
 <template>
 	<div class="range-picker">
-		<KernDatePicker v-model="start" v-bind="props" />
+		<KernDatePicker v-model="start" v-bind="$props" />
 		–
-		<KernDatePicker v-model="end" v-bind="props" />
+		<KernDatePicker v-model="end" v-bind="$props" />
 	</div>
 </template>
 
 <script setup lang="ts">
 import KernDatePicker from './KernDatePicker.ce.vue'
 
-const props = defineProps<{
+defineProps<{
 	min?: Date
 	max?: Date
 }>()

--- a/src/components/kern/KernRadioGroup.ce.vue
+++ b/src/components/kern/KernRadioGroup.ce.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-for="(item, idx) of $props.items" :key="idx" class="kern-form-check">
+	<div v-for="(item, idx) of items" :key="idx" class="kern-form-check">
 		<input
 			:id="id + '-' + idx"
 			v-model="model"

--- a/src/components/kern/KernRadioGroup.ce.vue
+++ b/src/components/kern/KernRadioGroup.ce.vue
@@ -1,5 +1,5 @@
 <template>
-	<div v-for="(item, idx) of props.items" :key="idx" class="kern-form-check">
+	<div v-for="(item, idx) of $props.items" :key="idx" class="kern-form-check">
 		<input
 			:id="id + '-' + idx"
 			v-model="model"
@@ -18,7 +18,7 @@ import { useId } from 'vue'
 
 import type { Icon } from '@/core'
 
-const props = defineProps<{
+defineProps<{
 	items: {
 		value: string
 		label: string

--- a/src/plugins/filter/components/FilterCategory.ce.vue
+++ b/src/plugins/filter/components/FilterCategory.ce.vue
@@ -16,9 +16,10 @@
 			<KernBlockButton
 				v-if="category.selectAll"
 				icon="kern-icon--deselect"
-				:label="$t(($) => $.category.deselectAll, { ns: PluginId })"
 				@click="filterStore.selectOrDeselectAllFromCategory(category)"
-			/>
+			>
+				{{ $t(($) => $.category.deselectAll, { ns: PluginId }) }}
+			</KernBlockButton>
 			<component
 				:is="
 					coreStore.layout === 'standard'
@@ -28,15 +29,6 @@
 				v-for="categoryValue of category.knownValues"
 				:key="flattenValue(categoryValue)"
 				:icon="typeof categoryValue !== 'string' && categoryValue.icon"
-				:label="
-					$t(
-						($) =>
-							$['layer'][filterStore.selectedLayerId]['category'][
-								category.targetProperty
-							]['knownValue'][flattenValue(categoryValue)],
-						{ ns: PluginId, defaultValue: flattenValue(categoryValue) }
-					)
-				"
 				:model-value="
 					filterStore.getCategoryStatus(
 						category.targetProperty,
@@ -50,7 +42,17 @@
 						$event
 					)
 				"
-			/>
+			>
+				{{
+					$t(
+						($) =>
+							$['layer'][filterStore.selectedLayerId]['category'][
+								category.targetProperty
+							]['knownValue'][flattenValue(categoryValue)],
+						{ ns: PluginId, defaultValue: flattenValue(categoryValue) }
+					)
+				}}
+			</component>
 		</div>
 	</FilterSection>
 </template>

--- a/src/plugins/layerChooser/components/LayerOptions.ce.vue
+++ b/src/plugins/layerChooser/components/LayerOptions.ce.vue
@@ -10,7 +10,6 @@
 				<PolarInput
 					v-model="activeLayers"
 					id-suffix="polar-layer-chooser-mask-options"
-					:label="displayName"
 					type="checkbox"
 					:value="layerName"
 					:class="
@@ -21,7 +20,9 @@
 					:disabled="
 						activeLayers.length === 1 && activeLayers.includes(layerName)
 					"
-				/>
+				>
+					{{ displayName }}
+				</PolarInput>
 			</div>
 		</PolarInputGroup>
 	</LayerInformationCard>

--- a/src/plugins/layerChooser/components/LayerSelection.ce.vue
+++ b/src/plugins/layerChooser/components/LayerSelection.ce.vue
@@ -12,11 +12,12 @@
 				<PolarInput
 					v-model="activeBackgroundId"
 					:id-suffix="`polar-layer-chooser-background`"
-					:label="name"
 					type="radio"
 					:value="id"
 					:disabled="disabledBackgrounds[id]"
-				/>
+				>
+					{{ name }}
+				</PolarInput>
 				<LegendButton
 					v-if="layersWithLegendsIds.includes(id)"
 					:id="id"
@@ -41,11 +42,12 @@
 						<PolarInput
 							v-model="activeMaskIds"
 							:id-suffix="`polar-layer-chooser-mask-${type}`"
-							:label="name"
 							type="checkbox"
 							:value="id"
 							:disabled="disabledMasks[id]"
-						/>
+						>
+							{{ name }}
+						</PolarInput>
 						<button
 							v-if="Object.keys(layersWithOptions).includes(id)"
 							:id="`polar-layer-chooser-options-${id}-button`"


### PR DESCRIPTION
## Summary

Make the changes of the kern components feel more natural and reduce bloat by removing unnecessary variables.

## Instructions for local reproduction and review

As only the filter plugins currently uses these components, run `snowbox` and check whether it still looks fine.
