### PR TITLE
fix(core): remove cycles that were hidden by vite imports

### DIFF
--- a/src/core/components/PolarContainer.ce.vue
+++ b/src/core/components/PolarContainer.ce.vue
@@ -48,6 +48,7 @@ import { useCoreStore } from '../stores'
 import { useMainStore } from '../stores/main'
 import { useMoveHandleStore } from '../stores/moveHandle'
 import { loadKern } from '../utils/loadKern'
+import { teardownMarkers } from '../utils/map/setupMarkers'
 import { mapZoomOffset } from '../utils/mapZoomOffset'
 import MoveHandle from './MoveHandle.ce.vue'
 import PolarMap from './PolarMap.ce.vue'
@@ -220,6 +221,9 @@ onBeforeUnmount(() => {
 	i18next.off('languageChanged', updateLanguage)
 
 	const mapEl = mainStore.map.getTargetElement()
+	if (mainStore.configuration.markers) {
+		teardownMarkers(mainStore.map)
+	}
 	mainStore.map.dispose()
 	mapEl.replaceChildren()
 	delete (mainStore.lightElement as { store?: unknown }).store

--- a/src/core/stores/main.ts
+++ b/src/core/stores/main.ts
@@ -6,9 +6,6 @@ import { toMerged } from 'es-toolkit'
 import { acceptHMRUpdate, defineStore } from 'pinia'
 import { computed, ref, shallowRef, watch } from 'vue'
 
-import { teardownMarkers } from '@/core/utils/map/setupMarkers.ts'
-import { teardownInteractions } from '@/core/utils/map/updateDragAndZoomInteractions.ts'
-
 import type {
 	ColorScheme,
 	MapConfigurationIncludingDefaults,
@@ -18,6 +15,7 @@ import type {
 import { addInterceptor } from '../utils/addInterceptor'
 import { SMALL_DISPLAY_HEIGHT, SMALL_DISPLAY_WIDTH } from '../utils/constants'
 import defaults from '../utils/defaults'
+import { teardownInteractions } from '../utils/map/updateDragAndZoomInteractions'
 
 export const useMainStore = defineStore('main', () => {
 	const colorScheme = ref<ColorScheme>('system')
@@ -100,9 +98,6 @@ export const useMainStore = defineStore('main', () => {
 	function teardown() {
 		removeEventListener('resize', updateHasSmallDisplay)
 		teardownInteractions()
-		if (configuration.value.markers) {
-			teardownMarkers(map.value)
-		}
 	}
 
 	return {


### PR DESCRIPTION
## Summary

Some cyclic references were previously hidden by the vite import aliases which are now resolved.

## Instructions for local reproduction and review

The pipelines should still be green.
