### PR TITLE
(#618) Automatically remove previews from gh-pages

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,5 +1,7 @@
 name: Deploy PR previews
 
+concurrency: preview-${{ github.ref }}
+
 on:
   pull_request:
     types:
@@ -31,19 +33,23 @@ jobs:
           cache: 'npm'
 
       - name: Install documentation build dependencies
+        if: github.event.action != 'closed'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends mkdocs mkdocs-material
 
       - name: Install NPM dependencies
+        if: github.event.action != 'closed'
         run: npm ci
 
       - name: Build preview
+        if: github.event.action != 'closed'
         run: |
           npm run build:ci
           npm run preview:build:ci -- --base="./"
 
       - name: Build documentation
+        if: github.event.action != 'closed'
         run: |
           npm run docs:ci
           mv docs-html ./.dist.preview/docs-html


### PR DESCRIPTION
## Summary

Removal of previews from GH-pages fails too often.

## Instructions for local reproduction and review

- Merge PR
- See the still existing preview

For obvious reasons, this PR is untested.

## Relevant tickets, issues, et cetera

Hopefully reduces #618 