### PR TITLE
fix(addressSearch): display SearchResults above icon buttons

### DIFF
--- a/src/plugins/addressSearch/components/AddressSearch.ce.vue
+++ b/src/plugins/addressSearch/components/AddressSearch.ce.vue
@@ -166,6 +166,7 @@ function inputDown(event: KeyboardEvent) {
 	);
 	width: 25rem;
 	min-width: inherit;
+	z-index: 1;
 
 	&:deep(.kern-card__container) {
 		flex: 0 1 auto;


### PR DESCRIPTION
## Summary

Add z-index so the SearchResults are displayed above icon buttons (e.g. export).

## Instructions for local reproduction and review

Take a look at snowbox and marvel at the neatly visible SearchResults after a successful search.
