### PR TITLE
Dish/dish export map/selected backgroundlayer in print

### DIFF
--- a/packages/clients/dish/CHANGELOG.md
+++ b/packages/clients/dish/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## 1.6.0
+
 - Feature: Use selected background service for print in `DishExportMap`.
 - Fix: Add new parameter `printImageBaseUrl` to urlParams needed for printing in qs and prod environment.
 

--- a/packages/clients/dish/CHANGELOG.md
+++ b/packages/clients/dish/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.6.0
+- Feature: Use selected background service for print in `DishExportMap`.
+- Fix: Add new parameter `printImageBaseUrl` to urlParams needed for printing in qs and prod environment.
+
 ## 1.5.0
 
 - Feature: Split gfi field "Flurstück" into "Flurstückszähler" and "Flurstücknenner".

--- a/packages/clients/dish/src/index.html
+++ b/packages/clients/dish/src/index.html
@@ -30,20 +30,20 @@
       const internalHost = 'https://dish-testumgebung.dsc.dataport.de/deegree'
       const internalPort = ''
       const internalPath = 'dish-deegree-3.5.0/services'
+      const internalHostForGfi = 'https://dish-testumgebung.dsc.dataport.de'
 
       // configuration for backend print services
       const printHostDeegree = "http://10.61.63.54"
       const printHostPort = "8081"
       const printPath = "dish-deegree-3.5.0/services"
-      const internalHostForGfi = 'https://dish-testumgebung.dsc.dataport.de'
-      const printImageUrlProd = printHostDeegree // only needed for prod, otherwise the same as printHostDegree
+      const printImageBaseUrl = printHostDeegree // only needed for prod, otherwise the same as printHostDegree
 
       // leave empty for external map
       const urlParams = {
         internalHost,
         printHostDeegree,
-        printImageUrlProd,
-        printServicesBaseUrl: `${printHostDeegree}:${printHostPort}/${printPath}`,
+        printImageBaseUrl,
+        printServicesBaseUrl: `${printImageBaseUrl}:${printHostPort}/${printPath}`,
         internServicesBaseUrl: `${internalHost}/${internalPath}`
       }
 

--- a/packages/clients/dish/src/index.html
+++ b/packages/clients/dish/src/index.html
@@ -36,11 +36,13 @@
       const printHostPort = "8081"
       const printPath = "dish-deegree-3.5.0/services"
       const internalHostForGfi = 'https://dish-testumgebung.dsc.dataport.de'
+      const printImageUrlProd = printHostDeegree // only needed for prod, otherwise the same as printHostDegree
 
       // leave empty for external map
       const urlParams = {
         internalHost,
         printHostDeegree,
+        printImageUrlProd,
         printServicesBaseUrl: `${printHostDeegree}:${printHostPort}/${printPath}`,
         internServicesBaseUrl: `${internalHost}/${internalPath}`
       }

--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -179,7 +179,7 @@ export const mapConfigIntern = (urlParams: DishUrlParams): DishMapConfig => ({
     wmsLayerUrl: `${urlParams.printServicesBaseUrl}/wms`,
     wfsLayerUrl: `${urlParams.printServicesBaseUrl}/wfs`,
     wfsLayerFeatureType: 'app:TBLGIS_ORA',
-    printImageUrlProd: `${urlParams.printImageUrlProd}/Content/MapsTmp`,
+    printImageUrlProd: urlParams.printImageUrlProd ? `${urlParams.printImageUrlProd}/Content/MapsTmp` : `${urlParams.printHostDeegree}/Content/MapsTmp` ,
     exportMapAsPdfUrl: `${urlParams.printHostDeegree}/Content/Objekt/Kartenausgabe.aspx`,
   },
 })

--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -12,7 +12,7 @@ import {
   verwaltung,
 } from '../servicesConstants'
 import { shBlue } from '../colors'
-import { DishMapConfig, DishUrlParams, backgroundLayer } from '../types'
+import { DishMapConfig, DishUrlParams } from '../types'
 import {
   categoryProps,
   groupProperties,
@@ -181,9 +181,5 @@ export const mapConfigIntern = (urlParams: DishUrlParams): DishMapConfig => ({
     wfsLayerFeatureType: 'app:TBLGIS_ORA',
     printImageUrlProd: `${urlParams.printHostDeegree}/Content/MapsTmp`,
     exportMapAsPdfUrl: `${urlParams.printHostDeegree}/Content/Objekt/Kartenausgabe.aspx`,
-    backgroundLayer: {
-      url: 'https://sgx.geodatenzentrum.de/wms_basemapde',
-      layers: 'de_basemapde_web_raster_grau',
-    } as backgroundLayer,
   },
 })

--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -180,6 +180,6 @@ export const mapConfigIntern = (urlParams: DishUrlParams): DishMapConfig => ({
     wfsLayerUrl: `${urlParams.printServicesBaseUrl}/wfs`,
     wfsLayerFeatureType: 'app:TBLGIS_ORA',
     printImageUrlProd: `${urlParams.printImageUrlProd}/Content/MapsTmp`,
-    exportMapAsPdfUrl: `${urlParams.internalHost}/Content/Objekt/Kartenausgabe.aspx`,
+    exportMapAsPdfUrl: `${urlParams.printHostDeegree}/Content/Objekt/Kartenausgabe.aspx`,
   },
 })

--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -179,7 +179,7 @@ export const mapConfigIntern = (urlParams: DishUrlParams): DishMapConfig => ({
     wmsLayerUrl: `${urlParams.printServicesBaseUrl}/wms`,
     wfsLayerUrl: `${urlParams.printServicesBaseUrl}/wfs`,
     wfsLayerFeatureType: 'app:TBLGIS_ORA',
-    printImageUrlProd: urlParams.printImageUrlProd ? `${urlParams.printImageUrlProd}/Content/MapsTmp` : `${urlParams.printHostDeegree}/Content/MapsTmp` ,
+    printImageUrlProd: urlParams.printImageBaseUrl ? `${urlParams.printImageBaseUrl}/Content/MapsTmp` : `${urlParams.printHostDeegree}/Content/MapsTmp` ,
     exportMapAsPdfUrl: `${urlParams.printHostDeegree}/Content/Objekt/Kartenausgabe.aspx`,
   },
 })

--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -179,7 +179,7 @@ export const mapConfigIntern = (urlParams: DishUrlParams): DishMapConfig => ({
     wmsLayerUrl: `${urlParams.printServicesBaseUrl}/wms`,
     wfsLayerUrl: `${urlParams.printServicesBaseUrl}/wfs`,
     wfsLayerFeatureType: 'app:TBLGIS_ORA',
-    printImageUrlProd: `${urlParams.printHostDeegree}/Content/MapsTmp`,
-    exportMapAsPdfUrl: `${urlParams.printHostDeegree}/Content/Objekt/Kartenausgabe.aspx`,
+    printImageUrlProd: `${urlParams.printImageUrlProd}/Content/MapsTmp`,
+    exportMapAsPdfUrl: `${urlParams.internalHost}/Content/Objekt/Kartenausgabe.aspx`,
   },
 })

--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -179,7 +179,9 @@ export const mapConfigIntern = (urlParams: DishUrlParams): DishMapConfig => ({
     wmsLayerUrl: `${urlParams.printServicesBaseUrl}/wms`,
     wfsLayerUrl: `${urlParams.printServicesBaseUrl}/wfs`,
     wfsLayerFeatureType: 'app:TBLGIS_ORA',
-    printImageUrlProd: urlParams.printImageBaseUrl ? `${urlParams.printImageBaseUrl}/Content/MapsTmp` : `${urlParams.printHostDeegree}/Content/MapsTmp` ,
+    printImageUrlProd: urlParams.printImageBaseUrl
+      ? `${urlParams.printImageBaseUrl}/Content/MapsTmp`
+      : `${urlParams.printHostDeegree}/Content/MapsTmp`,
     exportMapAsPdfUrl: `${urlParams.printHostDeegree}/Content/Objekt/Kartenausgabe.aspx`,
   },
 })

--- a/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
+++ b/packages/clients/dish/src/mapConfigurations/mapConfigIntern.ts
@@ -179,9 +179,9 @@ export const mapConfigIntern = (urlParams: DishUrlParams): DishMapConfig => ({
     wmsLayerUrl: `${urlParams.printServicesBaseUrl}/wms`,
     wfsLayerUrl: `${urlParams.printServicesBaseUrl}/wfs`,
     wfsLayerFeatureType: 'app:TBLGIS_ORA',
-    printImageUrlProd: urlParams.printImageBaseUrl
-      ? `${urlParams.printImageBaseUrl}/Content/MapsTmp`
-      : `${urlParams.printHostDeegree}/Content/MapsTmp`,
+    printImageUrlProd: `${
+      urlParams.printImageBaseUrl ?? urlParams.printHostDeegree
+    }/Content/MapsTmp`,
     exportMapAsPdfUrl: `${urlParams.printHostDeegree}/Content/Objekt/Kartenausgabe.aspx`,
   },
 })

--- a/packages/clients/dish/src/plugins/DishExportMap/DishExportMap.vue
+++ b/packages/clients/dish/src/plugins/DishExportMap/DishExportMap.vue
@@ -85,6 +85,7 @@ export default Vue.extend({
   }),
   computed: {
     ...mapGetters(['map', 'configuration']),
+    ...mapGetters('plugin/layerChooser', ['activeBackgroundId']),
     ...mapGetters('plugin/pins', ['transformedCoordinate']),
     ...mapGetters('plugin/gfi', ['currentProperties']),
     ...mapGetters('plugin/scale', ['scaleValue', 'scaleWithUnit']),
@@ -94,8 +95,9 @@ export default Vue.extend({
     },
     backgroundLayer() {
       return (
-        this.configuration.dishExportMap.backgroundLayer ||
-        this.defaultBackground
+        this.configuration.layerConf.find(
+          (layer) => layer.id === this.activeBackgroundId
+        ) || this.defaultBackground
       )
     },
     dishExportMap() {

--- a/packages/clients/dish/src/plugins/DishExportMap/README.md
+++ b/packages/clients/dish/src/plugins/DishExportMap/README.md
@@ -23,11 +23,12 @@ The following parameters for the plugin must be defined in the map configuration
 | versionWFS | string |  Version for WFS. |
 | propertyNameWFS | string | No description available. |
 | filterTypeWFS | string | No description available. |
-| printImageUrlProd | internalHost + '/Content/MapsTmp' | Probably the URL to the created map section. The internalHost is set in the urlParams. |
+| printImageUrlProd | `printImageBaseUrl` + /Content/MapsTmp | Probably the URL to the created map section. Only necessary for production, otherwise the same as `printHostDegree`. `printImageBaseUrl` and `printHostDegree` are set in the urlParams. |
 | wmsLayerUrl | string | The url to the WMS used for the print. |
 | wfsLayerUrl | string | The url to the WFS used for the print. |
 | wfsLayerFeatureType | string | The feature type of the wfs configured in wfsLayerUrl. |
-| printImagePath | string |  Probably the relative path to the created map section. |
+| printImagePath | string |  Probably the relative path to the created map image that is used in the pdf print. |
+| exportMapAsPdfUrl | `printHostDeegree` + /Content/Objekt/Kartenausgabe.aspx | The path to the created pdf. `printHostDegree` is set in the urlParams. |
 
 
 ### example configuration

--- a/packages/clients/dish/src/plugins/DishExportMap/README.md
+++ b/packages/clients/dish/src/plugins/DishExportMap/README.md
@@ -28,7 +28,6 @@ The following parameters for the plugin must be defined in the map configuration
 | wfsLayerUrl | string | The url to the WFS used for the print. |
 | wfsLayerFeatureType | string | The feature type of the wfs configured in wfsLayerUrl. |
 | printImagePath | string |  Probably the relative path to the created map section. |
-| backgroundLayer | backgroundLayer | An object with `url` and `layers` properties. `url` specifies the WMS service URL for the background layer, and `layers` specifies the layer names to display. |
 
 
 ### example configuration
@@ -53,7 +52,6 @@ dishExportMap: {
   wfsLayerFeatureType: 'app:TBLGIS_ORA',
   printImageUrlProd: `${urlParams.internalHost}/Content/MapsTmp`,
   exportMapAsPdfUrl: `${urlParams.internalHost}/Content/Objekt/Kartenausgabe.aspx`,
-  backgroundLayer: {url: 'https://sgx.geodatenzentrum.de/wms_basemapde', layers: 'de_basemapde_web_raster_grau'}
 },
 ```
 

--- a/packages/clients/dish/src/types.ts
+++ b/packages/clients/dish/src/types.ts
@@ -129,7 +129,7 @@ export interface DishMapConfig
     wmsLayerUrl: string
     wfsLayerUrl: string
     wfsLayerFeatureType: string
-    printImageUrlProd: string
+    printImageUrlProd?: string
     exportMapAsPdfUrl: string
   }
 }

--- a/packages/clients/dish/src/types.ts
+++ b/packages/clients/dish/src/types.ts
@@ -130,13 +130,7 @@ export interface DishMapConfig
     wfsLayerFeatureType: string
     printImageUrlProd: string
     exportMapAsPdfUrl: string
-    backgroundLayer: backgroundLayer
   }
-}
-
-export interface backgroundLayer {
-  url: string
-  layers: string
 }
 
 export interface SelectionObjectState {

--- a/packages/clients/dish/src/types.ts
+++ b/packages/clients/dish/src/types.ts
@@ -104,7 +104,7 @@ export interface DishUrlParams {
   internServicesBaseUrl: string
   printHostDeegree: string
   printServicesBaseUrl: string
-  printImageUrlProd: string
+  printImageBaseUrl?: string
 }
 
 export interface DishMapConfig

--- a/packages/clients/dish/src/types.ts
+++ b/packages/clients/dish/src/types.ts
@@ -104,6 +104,7 @@ export interface DishUrlParams {
   internServicesBaseUrl: string
   printHostDeegree: string
   printServicesBaseUrl: string
+  printImageUrlProd: string
 }
 
 export interface DishMapConfig


### PR DESCRIPTION
## Summary

DishExportMap should use the selected background layer as background in the print. 

It also seems like we need another urlParam for prod and qs, because the base service url for print services differ from `printHostDegree`.

## Instructions for local reproduction and review

- start client in mode 'INTERN'
- change background layer to basemap
- click on a monument feature in the map. You might need to zoom in to be able to click them. you need to use the split tunnel to be able to request the monument feature service
- select "Kartendruck"
- a new tab opens in DISH with a login formular (ask me for user / pw)
- login and redo the steps above. Instead of a login formular you should get a pdf with a map from the feature you clicked on.

Unfortunately, we cannot request the other services (Grundkarte Graustufen, Grundkarte Farbe, Luftbilder Farbe), so it is only possible to see a result with basemap. But you can check the URLs to see if the other service urls are used in there.



## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
