### PR TITLE
fix: add name prop so radio inputs are properly grouped together 

### DIFF
--- a/src/components/PolarInput.ce.vue
+++ b/src/components/PolarInput.ce.vue
@@ -4,7 +4,7 @@
 			:id="`polar-${type}-${value}-${idSuffix}`"
 			v-model="model"
 			:class="`polar-input kern-form-check__${type}`"
-			:name="value"
+			:name="name"
 			:value="value"
 			:type="type"
 			:disabled="disabled"
@@ -23,6 +23,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const props = defineProps<{
 	idSuffix: string
+	name: string
 	type: T
 	value: string
 	disabled?: boolean

--- a/src/plugins/layerChooser/components/LayerOptions.ce.vue
+++ b/src/plugins/layerChooser/components/LayerOptions.ce.vue
@@ -11,6 +11,7 @@
 					v-model="activeLayers"
 					id-suffix="polar-layer-chooser-mask-options"
 					type="checkbox"
+					name="polar-layer-chooser-mask-options"
 					:value="layerName"
 					:class="
 						options.some(({ layerImage }) => layerImage !== null)

--- a/src/plugins/layerChooser/components/LayerSelection.ce.vue
+++ b/src/plugins/layerChooser/components/LayerSelection.ce.vue
@@ -12,6 +12,7 @@
 				<PolarInput
 					v-model="activeBackgroundId"
 					:id-suffix="`polar-layer-chooser-background`"
+					name="polar-layer-chooser-background"
 					type="radio"
 					:value="id"
 					:disabled="disabledBackgrounds[id]"
@@ -42,6 +43,7 @@
 						<PolarInput
 							v-model="activeMaskIds"
 							:id-suffix="`polar-layer-chooser-mask-${type}`"
+							name="polar-layer-chooser-mask"
 							type="checkbox"
 							:value="id"
 							:disabled="disabledMasks[id]"


### PR DESCRIPTION
## Summary

Radio inputs are only grouped together in a tab group if they share the same `name` attribute. This PR introduces that as a new prop.

## Instructions for local reproduction and review

`npm run snowbox` -> The radio inputs in layerChooser now should only be reachable with one tab and navigatable with arrow keys.
