### PR TITLE
fix(layerChooser): correctly interpolate legend button locale

### DIFF
--- a/src/plugins/layerChooser/components/LayerSelection.ce.vue
+++ b/src/plugins/layerChooser/components/LayerSelection.ce.vue
@@ -22,6 +22,7 @@
 				<LegendButton
 					v-if="layersWithLegendsIds.includes(id)"
 					:id="id"
+					:name="name"
 					:disabled="disabledBackgrounds[id]"
 					@click="openedLegendId = id"
 				/>
@@ -68,6 +69,7 @@
 						<LegendButton
 							v-else-if="layersWithLegendsIds.includes(id)"
 							:id="id"
+							:name="name"
 							:disabled="disabledMasks[id]"
 							@click="openedLegendId = id"
 						/>

--- a/src/plugins/layerChooser/components/LegendButton.ce.vue
+++ b/src/plugins/layerChooser/components/LegendButton.ce.vue
@@ -6,7 +6,7 @@
 	>
 		<span class="kern-icon kern-icon--info" aria-hidden="true" />
 		<span class="kern-label kern-sr-only">
-			{{ $t(($) => $.legend.open, { ns: PluginId }) }}
+			{{ $t(($) => $.legend.open, { ns: PluginId, name }) }}
 		</span>
 	</button>
 </template>
@@ -17,5 +17,6 @@ import { PluginId } from '../types'
 defineProps<{
 	disabled: boolean
 	id: string
+	name: string
 }>()
 </script>

--- a/src/plugins/layerChooser/locales.ts
+++ b/src/plugins/layerChooser/locales.ts
@@ -23,7 +23,7 @@ export const resourcesDe = {
 	legend: {
 		title: 'Legende',
 		to: 'Legendenbild zu "{{name}}"',
-		open: `$t(legend.to, {ns: ${PluginId}}) öffnen`,
+		open: `$t(${PluginId}:legend.to, { name: {{name}} ) öffnen`,
 	},
 	returnToLayers: 'Zurück',
 } as const
@@ -40,7 +40,7 @@ export const resourcesEn = {
 	legend: {
 		title: 'Legend',
 		to: '"{{name}}" legend image',
-		open: `Open $t(legend.to, {ns: ${PluginId}})`,
+		open: `Open $t(${PluginId}:legend.to, { name: {{name}} })`,
 	},
 	returnToLayers: 'Back',
 } as const


### PR DESCRIPTION
## Summary

Namespaces behave a bit differently in other locales. Also, the interpolation was completely amiss.

## Instructions for local reproduction and review

`npm run snowbox` -> the legend buttons should now use a correct label.
