### PR TITLE
fix: stop clean script from deleting vendored dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "textLocator:dev": "nx dev @polar/client-text-locator",
     "pages:build": "rimraf ./pages/docs && npm run generic:build && bash ./scripts/buildPages.sh",
     "pages:build:serve": "http-server pages -o index.html",
-    "clean": "nx reset && rimraf --glob packages/**/{.cache,dist,docs} && rimraf --glob {.cache,dist} && node ./scripts/clean",
+    "clean": "node ./scripts/clean",
     "docs:afm": "tsx ./scripts/makeDocs afm",
     "docs:diplan": "npm run diplan:build && cp -r ./packages/clients/diplan/dist ./packages/clients/diplan/example ./packages/clients/diplan/docs",
     "docs:generic": "tsx ./scripts/makeDocs generic",

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,16 +1,21 @@
 /* eslint-disable no-console */
 const { exec } = require('child_process') // eslint-disable-line
+const { promisify } = require('util') // eslint-disable-line
 const os = require('os') // eslint-disable-line
+const { rimraf } = require('rimraf') // eslint-disable-line
 
-const isWindows = os.platform() === 'win32'
+const execAsync = promisify(exec)
 
 async function clean() {
-  if (isWindows) {
-    await exec('rmdir /s /q node_modules')
-    console.log('node_modules were purged.')
-    return
-  }
-  await exec('rm -rf node_modules')
-  console.log('node_modules were purged.')
+  await execAsync('nx reset')
+  console.log('nx cache was reset.')
+
+  await rimraf('{.cache,dist,node_modules}', { glob: true })
+  await rimraf('packages/**/{.cache,dist,docs}', {
+    glob: { ignore: 'packages/clients/diplan/vendored/**' },
+  })
+  console.log(
+    'Build artifacts (.cache, dist, docs) and node_modules were purged.'
+  )
 }
 clean()

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -11,7 +11,7 @@ async function clean() {
   console.log('nx cache was reset.')
 
   await rimraf('{.cache,dist,node_modules}', { glob: true })
-  await rimraf('packages/**/{.cache,dist,docs}', {
+  await rimraf('packages/**/{.cache,dist,docs,node_modules}', {
     glob: { ignore: 'packages/clients/diplan/vendored/**' },
   })
   console.log(


### PR DESCRIPTION
## Summary

Move package.json script to clean.js, prevent deletion of vendored dist folder there.

## Instructions for local reproduction and review

`npm i && npm run clean && git status`

Nothing should have changed, but the cleaning should still be thorough.
