### PR TITLE
chore: fix dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -62,7 +62,7 @@
 				"vite-plugin-vue-devtools": "^8.1.2",
 				"vitest": "^4.1.8",
 				"vue": "^3.5.38",
-				"vue-tsc": "^3.3.4",
+				"vue-tsc": "^3.3.5",
 				"xml2js": "^0.6.2"
 			},
 			"engines": {
@@ -14168,14 +14168,14 @@
 			}
 		},
 		"node_modules/vue-tsc": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.4.tgz",
-			"integrity": "sha512-XA/JqmQwS2GZmfgpjOEGdrKwaTSEuPwxpHa7/t6f4yiGrJb3gVHTPb9wBfByMNZwQ+xDXs41b8gaS2DKsOozUw==",
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.3.5.tgz",
+			"integrity": "sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@volar/typescript": "2.4.28",
-				"@vue/language-core": "3.3.4"
+				"@vue/language-core": "3.3.5"
 			},
 			"bin": {
 				"vue-tsc": "bin/vue-tsc.js"
@@ -14185,9 +14185,9 @@
 			}
 		},
 		"node_modules/vue-tsc/node_modules/@vue/language-core": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.4.tgz",
-			"integrity": "sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==",
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.3.5.tgz",
+			"integrity": "sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -149,13 +149,13 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -171,9 +171,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.29.3",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-			"integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+			"integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -181,21 +181,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+			"integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-compilation-targets": "^7.28.6",
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helpers": "^7.28.6",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/traverse": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-compilation-targets": "^7.29.7",
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helpers": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -222,14 +222,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -252,14 +252,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+			"integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.28.6",
-				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/compat-data": "^7.29.7",
+				"@babel/helper-validator-option": "^7.29.7",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
@@ -321,9 +321,9 @@
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -345,29 +345,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -452,9 +452,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-			"integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+			"integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -462,14 +462,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+			"integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0"
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -617,33 +617,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -4276,9 +4276,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.27",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-			"integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+			"version": "2.10.37",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz",
+			"integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -4502,9 +4502,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001792",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-			"integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+			"version": "1.0.30001799",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+			"integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5333,9 +5333,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
-			"integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+			"version": "3.4.10",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+			"integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
 			"dev": true,
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
@@ -5495,9 +5495,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.352",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.352.tgz",
-			"integrity": "sha512-9wHk8x6dyuimoe18EdiDPWKExNdxYqo4fn4FwOVVper6RxT3cmpBwBkWWfSOCYJjQdIco/nPhJhNLmn4Ufg1Yg==",
+			"version": "1.5.372",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz",
+			"integrity": "sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -8289,14 +8289,11 @@
 			}
 		},
 		"node_modules/js-cookie": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-			"integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+			"version": "3.0.8",
+			"resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+			"integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			}
+			"license": "MIT"
 		},
 		"node_modules/js-tokens": {
 			"version": "10.0.0",
@@ -8306,10 +8303,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -8970,10 +8977,20 @@
 			"license": "MIT"
 		},
 		"node_modules/linkify-it": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+			"integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"uc.micro": "^2.0.0"
@@ -9137,15 +9154,25 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/markdown-it": {
-			"version": "14.1.1",
-			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+			"version": "14.2.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+			"integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1",
 				"entities": "^4.4.0",
-				"linkify-it": "^5.0.0",
+				"linkify-it": "^5.0.1",
 				"mdurl": "^2.0.0",
 				"punycode.js": "^2.3.1",
 				"uc.micro": "^2.1.0"
@@ -10450,11 +10477,14 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.38",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-			"integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+			"version": "2.0.47",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+			"integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/node-stream": {
 			"version": "1.7.0",
@@ -11514,15 +11544,14 @@
 			"license": "ISC"
 		},
 		"node_modules/protobufjs": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.3.0.tgz",
-			"integrity": "sha512-JpJpFaR7yKNb6WqKvJJ1MLbiuIQWQnbUUb06nDtf2/i8YWYYLEfP6xf9BwSJoJQg1wAy61EQB8dssQg64oX4aA==",
+			"version": "8.6.3",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.3.tgz",
+			"integrity": "sha512-alQyzT0j401LGBtwsqu6uprjR6pfNH1UJf9N6GBFMjIcd+HzTe0/HrjAbFCqun+zvnfLarrxAtMM2xvZ+kFZ5A==",
 			"dev": true,
-			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"peer": true,
 			"dependencies": {
-				"long": "^5.0.0"
+				"long": "^5.3.2"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -12962,9 +12991,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tmp": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
 		"vite-plugin-vue-devtools": "^8.1.2",
 		"vitest": "^4.1.8",
 		"vue": "^3.5.38",
-		"vue-tsc": "^3.3.4",
+		"vue-tsc": "^3.3.5",
 		"xml2js": "^0.6.2"
 	},
 	"//": "Relevant overrides until the respective packages fix these vulnerable versions themselves.",


### PR DESCRIPTION
## Summary

- update vue-tsc to fix @vue/language-core regression (dea39b287b85cdffa17080aba030f2c3b2aaae64)
- resolve 7 npm audit vulnerabilities (e1527b857d04f805c0c46c860d38e0c933c5668e)

## Instructions for local reproduction and review

#734 should no longer have any type issues
