### PR TITLE
chore: change url for bathing area details

### DIFF
--- a/packages/clients/bgw/src/plugins/Gfi/ActionButton.vue
+++ b/packages/clients/bgw/src/plugins/Gfi/ActionButton.vue
@@ -21,7 +21,7 @@ export default Vue.extend({
   computed: {
     ...mapGetters('plugin/gfi', ['currentProperties']),
     link() {
-      return `https://www.schleswig-holstein.de/DE/fachinhalte/B/badegewaesser/DarstellungBadestelle.html#bgst=${this.currentProperties.fid}`
+      return `https://www.schleswig-holstein.de/DE/fachinhalte/G/gesundheitsschutz_umweltbezogen/Badegewaesser/DarstellungBadestelle.html#bgst=${this.currentProperties.fid}`
     },
   },
 })


### PR DESCRIPTION
## Summary

Change URL for poc bgw client because the url for details of the bathing areas has changed.

## Instructions for local reproduction and review

## Pull Request Checklist (for Assignee)

- [x] Changelogs are maintained
- [x] Functionality has been tested in Firefox, Chrome, Safari
- [x] Functionality has been tested on a smartphone
- [x] Functionality has been tested with 200% screen zoom
- [x] Screenreader functionality has been manually tested with NVDA

UI has been tested in the following tools regarding accessibility (only regarding functionality affected in this PR)
  - [x] Chrome Lighthouse
  - [x] Firefox Accessibility

## Relevant tickets, issues, et cetera
