### PR TITLE
ci: exclude local packages for dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
     open-pull-requests-limit: 20
     cooldown:
       default-days: 3
+      exclude:
+        - "@dataport/eslint-config-geodev"
+        - vite-plugin-kern-extra-icons
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
## Summary

Our packages do not have cooldown time. 
