### PR TITLE
ci: ignore @types/node major updates in dependabot to align with used node version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,3 +29,7 @@ updates:
       prefix: chore
       include: scope
     versioning-strategy: increase
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major


### PR DESCRIPTION
## Summary

Dependabot is trying to update `@types/node` to the latest major, which should not be happened.

## Instructions for local reproduction and review

Check the validity of the yaml.

## Relevant tickets, issues, et cetera

Resolves #817
