### PR TITLE
docs: fix references with `@link` and validate via CI

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -152,3 +152,31 @@ jobs:
 
       - name: Run type-checking
         run: npm run tsc:ci
+
+  typedoc:
+    name: Typedoc validation
+    needs: setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 24.15.0
+          registry-url: https://registry.npmjs.org/
+
+      - name: Restore node_modules
+        id: node-modules-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node24.15.0-${{ hashFiles('package-lock.json', 'patches/**') }}
+
+      - name: Install NPM dependencies (cache miss fallback)
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --no-audit --no-fund
+
+      - name: Run typedoc validation
+        run: npm run docs:ci:validate

--- a/.husky/defaults.json
+++ b/.husky/defaults.json
@@ -4,6 +4,7 @@
 	"lintOnCommit": false,
 	"lintCssOnCommit": false,
 	"typecheckOnCommit": false,
+	"typedocOnCommit": false,
 	"testOnCommit": false,
 
 	"skipCommitMsg": false,

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -73,3 +73,16 @@ then
 		exit 1
 	fi
 fi
+
+if [ "$POLAR_TYPEDOC_ON_COMMIT" = "yes" ]
+then
+	if ! npm run docs:ci:validate
+	then
+		echo "Cannot commit: Typedoc validation failed." >&2
+		echo "Please fix the above error(s)." >&2
+		echo >&2
+		echo "If you want to commit anyway, set POLAR_TYPEDOC_ON_COMMIT=no" >&2
+		echo "If you want to skip all pre-commit checks, set POLAR_SKIP_PRE_COMMIT=yes" >&2
+		exit 1
+	fi
+fi

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -96,6 +96,7 @@ const polarTsConfig = defineConfig({
 				allowNumber: true,
 			},
 		],
+		'tsdoc/syntax': 'off',
 
 		// POLAR-specific rules
 		'perfectionist/sort-interfaces': [

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
 		"tsc": "tsc && vue-tsc -p src && vue-tsc -p examples/iceberg",
 		"tsc:ci": "tsc && vue-tsc -p src && vue-tsc -p examples/iceberg",
 		"docs:ci": "npm run docs:showcase:ci && npm run docs:docs:ci && npm run docs:api:ci && npm run docs:api:core:ci && npm run docs:api:plugin:ci",
+		"docs:ci:validate": "typedoc --targetAudience core",
 		"docs:showcase:ci": "npm run build:github-io && mkdir -p docs-html && cp -r examples/github-io/dist/* docs-html/",
 		"docs:docs": "mkdocs serve",
 		"docs:docs:ci": "mkdocs build",

--- a/src/composables/useStoreWatcher.ts
+++ b/src/composables/useStoreWatcher.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/composables/useStoreWatcher
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { ComputedRef, WatchOptions, WatchStopHandle } from 'vue'
 import type { StoreReference } from '@/core/types'

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the main export for the NPM package \@polar/polar.
  *
@@ -7,7 +6,6 @@
  * @packageDocumentation
  * @module \@polar/polar
  */
-/* eslint-enable tsdoc/syntax */
 
 import { defineCustomElement } from 'vue'
 

--- a/src/core/locales.ts
+++ b/src/core/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in POLAR core.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/core
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from './types'
 

--- a/src/core/stores/index.ts
+++ b/src/core/stores/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import { acceptHMRUpdate, defineStore, storeToRefs } from 'pinia'
 import { computed } from 'vue'
@@ -12,13 +10,11 @@ import { useMarkerStore } from './marker'
 import { useMoveHandleStore } from './moveHandle'
 import { usePluginStore } from './plugin'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Core store of POLAR.
  */
-/* eslint-enable tsdoc/syntax */
 export const useCoreStore = defineStore('core', () => {
 	const mainStore = useMainStore()
 	const mainStoreRefs = storeToRefs(mainStore)
@@ -75,8 +71,7 @@ export const useCoreStore = defineStore('core', () => {
 		deviceIsHorizontal: computed(() => mainStore.deviceIsHorizontal),
 
 		/**
-		 * Whether the map has a maximum height of {@link SMALL_DISPLAY_HEIGHT} and
-		 * a maximum width of {@link SMALL_DISPLAY_WIDTH}.
+		 * Whether the map has a small display.
 		 *
 		 * @alpha
 		 * @readonly
@@ -165,7 +160,7 @@ export const useCoreStore = defineStore('core', () => {
 		 *
 		 * If no plugin with the specified ID is loaded, `null` is returned instead.
 		 *
-		 * @param pluginId - ID of the plugin whose store is requested.
+		 * @param id - ID of the plugin whose store is requested.
 		 */
 		getPluginStore: pluginStore.getPluginStore,
 
@@ -245,7 +240,7 @@ export const useCoreStore = defineStore('core', () => {
 
 		/**
 		 * Returns the effective layer configuration or `null` if the layer was not found.
-		 * The configuration is merged from the {@link createMap | serviceRegister parameter of createMap} and the POLAR {@link MapConfiguration.layers | layers} configuration.
+		 * The configuration is merged from the {@link @polar/polar!createMap | serviceRegister parameter of createMap} and the POLAR {@link @polar/polar!MapConfiguration.layers | layers} configuration.
 		 *
 		 * @param layerId - Layer ID
 		 * @returns Layer configuration (object) or `null`

--- a/src/core/types/layer.ts
+++ b/src/core/types/layer.ts
@@ -119,9 +119,9 @@ export interface LayerConfiguration {
 	options?: LayerConfigurationOptions
 
 	/**
-	 * ID of the used style. If the layer is also configured in {@link MapConfiguration.markers | `mapConfiguration.markers`},
+	 * ID of the used style. If the layer is also configured in {@link @polar/polar!MapConfiguration.markers | `mapConfiguration.markers`},
 	 * that configuration takes precedence over the configured `styleId`. Only applicable for vector-type layers.
-	 * For more information and an example see {@link MapConfiguration.featureStyles | `mapConfiguration.featureStyles`}.
+	 * For more information and an example see {@link @polar/polar!MapConfiguration.featureStyles | `mapConfiguration.featureStyles`}.
 	 * Defaults and fallbacks to OpenLayers default styling.
 	 */
 	styleId?: string

--- a/src/core/types/main.ts
+++ b/src/core/types/main.ts
@@ -184,7 +184,7 @@ export type ColorScheme = 'dark' | 'light' | 'system'
 export interface MapConfiguration extends MasterportalApiConfiguration {
 	/**
 	 * Configuration of layers that are supposed to be used in the respective client. All layers defined here have to have
-	 * an entry in the {@link createMap | `serviceRegister` parameter of `createMap`}. If `@polar/plugin-layer-chooser` is
+	 * an entry in the {@link @polar/polar!createMap | `serviceRegister` parameter of `createMap`}. If `@polar/plugin-layer-chooser` is
 	 * installed and configured, all these layers will be displayed in that menu.
 	 *
 	 * @example

--- a/src/core/types/marker.ts
+++ b/src/core/types/marker.ts
@@ -74,7 +74,7 @@ export interface MarkerLayer {
 }
 
 export interface MarkerLayerConfiguration {
-	/** Unique identifier of a layer configured in {@link MapConfiguration.layers | `mapConfiguration.layers`}. */
+	/** Unique identifier of a layer configured in {@link @polar/polar!MapConfiguration.layers | `mapConfiguration.layers`}. */
 	id: string
 
 	/**

--- a/src/core/types/plugin.ts
+++ b/src/core/types/plugin.ts
@@ -55,7 +55,7 @@ import type { Icon } from './theme'
  *
  * ## Custom Plugin Positioning
  *
- * There are two implemented layouting systems in POLAR configured by {@link MapConfiguration.layout}.
+ * There are two implemented layouting systems in POLAR configured by {@link @polar/polar!MapConfiguration.layout}.
  *
  * If `layout` is set to `'nineRegions'` all plugins are placed in a predefined region grid.
  * Use {@link PluginOptions.displayComponent | displayComponent} to control visibility
@@ -63,16 +63,16 @@ import type { Icon } from './theme'
  *
  * If `layout` is set to `'standard'`, a plugin can be rendered in one of two ways:
  * 1. **As part of the IconMenu**: Configure the plugin in the IconMenu's
- * 		{@link IconMenuPluginOptions.menus | `menus`} configuration.
+ * 		{@link @polar/polar/plugins/iconMenu!IconMenuPluginOptions.menus | `menus`} configuration.
  * 		The IconMenu will handle positioning and rendering the plugin at the designated location.
  * 2. **Independent with CSS positioning**: Directly add the plugin with
- * 		{@link addPlugin}. The plugin is responsible for its own positioning
+ * 		{@link @polar/polar!addPlugin | addPlugin}. The plugin is responsible for its own positioning
  * 		using CSS (e.g., `position: absolute`) within the map container.
  */
 export interface PluginOptions {
 	/**
 	 * Should the component be visible at all.
-	 * Only relevant if {@link MapConfiguration.layout | layout} is set to `'nineRegions'`.
+	 * Only relevant if {@link @polar/polar!MapConfiguration.layout | layout} is set to `'nineRegions'`.
 	 *
 	 * @defaultValue `false`
 	 */
@@ -80,7 +80,7 @@ export interface PluginOptions {
 
 	/**
 	 * The region where the plugin should be rendered.
-	 * Required if {@link MapConfiguration.layout | layout} is set to `'nineRegions'`,
+	 * Required if {@link @polar/polar!MapConfiguration.layout | layout} is set to `'nineRegions'`,
 	 * ignored otherwise.
 	 */
 	layoutTag?: keyof typeof NineLayoutTag
@@ -284,7 +284,7 @@ export interface PluginContainer {
 
 	/**
 	 * Configuration options. Please also note that all configuration added via plugin constructors can be overridden in
-	 * the {@link createMap | `createMap`'s parameter `mapConfiguration`} .
+	 * the {@link @polar/polar!createMap | `createMap`'s parameter `mapConfiguration`} .
 	 *
 	 * You may use either object (or a mix of them) to create the configuration, e.g. use the constructors for a base
 	 * configuration and the `mapConfiguration` object to override it for various use cases.

--- a/src/core/utils/export/store.ts
+++ b/src/core/utils/export/store.ts
@@ -67,7 +67,7 @@ export function subscribe<T extends StoreId>(
 }
 
 /**
- * Updates the parameter {@link parameterName | parameter} in the {@link storeName | store} with the {@link payload}.
+ * Updates the parameter `parameterName` in the `storeName` store with the `payload`.
  *
  * @param map - Map to update the value at.
  * @param storeName - Either `'core'` for the core store or the plugin ID for a plugin's store.

--- a/src/plugins/addressSearch/index.ts
+++ b/src/plugins/addressSearch/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/addressSearch
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { AddressSearchPluginOptions } from './types'
@@ -24,7 +22,7 @@ import { PluginId } from './types'
  * - WFS
  * - Hamburg WFS-G (`mpapi`), may fit some WFS-G outside HH, testing is advised
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginAddressSearch(
 	options: AddressSearchPluginOptions

--- a/src/plugins/addressSearch/locales.ts
+++ b/src/plugins/addressSearch/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the addressSearch plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/addressSearch
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/addressSearch/store.ts
+++ b/src/plugins/addressSearch/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/addressSearch/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PolarGeoJsonFeature } from '@/core'
 import type {
@@ -24,13 +22,11 @@ import { getResultsFromPromises } from './utils/getResultsFromPromises'
 import { getMethodContainer } from './utils/methodContainer'
 import SearchResultSymbols from './utils/searchResultSymbols'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for the address search.
  */
-/* eslint-enable tsdoc/syntax */
 export const useAddressSearchStore = defineStore(
 	'plugins/addressSearch',
 	() => {
@@ -348,7 +344,7 @@ export const useAddressSearchStore = defineStore(
 			/**
 			 * ID of the currently selected group.
 			 * Changing this triggers a new search with the currently set value
-			 * for {@link inputValue} if it has at least one character.
+			 * for `inputValue` if it has at least one character.
 			 */
 			selectedGroupId,
 

--- a/src/plugins/addressSearch/types.ts
+++ b/src/plugins/addressSearch/types.ts
@@ -54,7 +54,7 @@ export interface GroupProperties {
  *
  * @remarks
  * In {@link categoryProperties} and {@link groupProperties}, id strings called
- * {@link groupId} and {@link categoryId} are used. These are arbitrary strings
+ * `groupId` and `categoryId` are used. These are arbitrary strings
  * you can introduce and reuse to group or categorize elements together.
  */
 export interface AddressSearchPluginOptions extends PluginOptions {
@@ -74,9 +74,9 @@ export interface AddressSearchPluginOptions extends PluginOptions {
 
 	/**
 	 * An object defining properties for a category.
-	 * The searchMethod's {@link AddressSearchPluginOptions.categoryId | addressSearch.categoryId} is used as identifier.
+	 * The searchMethod's {@link SearchMethodConfiguration.categoryId | categoryId} is used as identifier.
 	 *
-	 * A service without categoryId default to the {@link AddressSearchPluginOptions.categoryId | addressSearch.categoryId}
+	 * A service without categoryId defaults to the {@link SearchMethodConfiguration.categoryId | categoryId}
 	 * `"default"`.
 	 */
 	categoryProperties?: Record<string, CategoryProperties>
@@ -130,6 +130,12 @@ export type SearchType = 'bkg' | 'wfs' | 'mpapi' | string
 
 export type SearchDisplayMode = 'mixed' | 'categorized'
 
+export type {
+	BKGParameters,
+	MpapiParameters,
+	WfsParameters,
+} from '../../lib/getFeatures/types'
+
 /** Object containing information for a specific search method. */
 export interface SearchMethodConfiguration {
 	/**
@@ -176,7 +182,7 @@ export interface SearchMethodConfiguration {
 
 	/**
 	 * The object further describes details for the search request.
-	 * Its contents vary by service type, see {@link BKGParameters}, {@link MpapiParameters} or {@link WfsParameters}.
+	 * Its contents vary by service type, see {@link @polar/polar/plugins/addressSearch!BKGParameters}, {@link @polar/polar/plugins/addressSearch!MpapiParameters} or {@link @polar/polar/plugins/addressSearch!WfsParameters}.
 	 */
 	queryParameters?: QueryParameters
 

--- a/src/plugins/attributions/index.ts
+++ b/src/plugins/attributions/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/attributions
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { AttributionsPluginOptions } from './types'
@@ -16,7 +14,7 @@ import { PluginId } from './types'
  * Creates a plugin which adds attributions (copyright information) regarding all currently active layers.
  * Additionally, static information can be added.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginAttributions(
 	options: AttributionsPluginOptions

--- a/src/plugins/attributions/locales.ts
+++ b/src/plugins/attributions/locales.ts
@@ -1,13 +1,11 @@
 import type { Locale } from '@/core'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the attributions plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/attributions
  */
-/* eslint-enable tsdoc/syntax */
 
 /**
  * German locales for attributions plugin.

--- a/src/plugins/attributions/store.ts
+++ b/src/plugins/attributions/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/attributions/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { StoreReference } from '@/core'
 import type { Attribution } from './types'
@@ -18,13 +16,11 @@ import { formatAttributionText } from './utils/formatAttributionText'
 import { getVisibleAttributions } from './utils/getVisibleAttributions.ts'
 import { getVisibleLayers } from './utils/getVisibleLayers'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for the attributions.
  */
-/* eslint-enable tsdoc/syntax */
 export const useAttributionsStore = defineStore('plugins/attributions', () => {
 	const coreStore = useCoreStore()
 

--- a/src/plugins/attributions/types.ts
+++ b/src/plugins/attributions/types.ts
@@ -71,8 +71,8 @@ export interface AttributionsPluginOptions extends PluginOptions {
 
 	/**
 	 * Whether the information box is open by default.
-	 * Only usable when {@link renderType} is set to `'independent'` and {@link MapConfiguration.layout | `layout`}
-	 * is set to `'nineRegions'` OR {@link MapConfiguration.layout | `layout`} is set to `'standard'`.
+	 * Only usable when {@link renderType} is set to `'independent'` and {@link @polar/polar!MapConfiguration.layout | `layout`}
+	 * is set to `'nineRegions'` OR {@link @polar/polar!MapConfiguration.layout | `layout`} is set to `'standard'`.
 	 * Otherwise, the IconMenu or the Footer handles this.
 	 */
 	initiallyOpen?: boolean
@@ -94,7 +94,7 @@ export interface AttributionsPluginOptions extends PluginOptions {
 	 * should always be visible (`'footer'`).
 	 *
 	 * @remarks
-	 * Only relevant if {@link MapConfiguration.layout | `layout`} is set to `'nineRegions'`,
+	 * Only relevant if {@link @polar/polar!MapConfiguration.layout | `layout`} is set to `'nineRegions'`,
 	 * as it is otherwise expected to be rendered as part of the Footer.
 	 *
 	 * @defaultValue 'independent'
@@ -107,8 +107,8 @@ export interface AttributionsPluginOptions extends PluginOptions {
 	staticAttributions?: string[]
 
 	/**
-	 * If {@link renderType} is set to `'independent'` and {@link MapConfiguration.layout | `layout`}
-	 * is set to `'nineRegions'` OR {@link MapConfiguration.layout | `layout`} is set to `'standard'`,
+	 * If {@link renderType} is set to `'independent'` and {@link @polar/polar!MapConfiguration.layout | `layout`}
+	 * is set to `'nineRegions'` OR {@link @polar/polar!MapConfiguration.layout | `layout`} is set to `'standard'`,
 	 * sets the width of the container of the attributions.
 	 *
 	 * @defaultValue 500

--- a/src/plugins/export/index.ts
+++ b/src/plugins/export/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/export
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { ExportPluginOptions } from './types'
@@ -18,7 +16,7 @@ import { PluginId } from './types'
  * loaded, or the canvas will no longer be printable due to potential security
  * issues.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginExport(
 	options: ExportPluginOptions

--- a/src/plugins/export/locales.ts
+++ b/src/plugins/export/locales.ts
@@ -1,13 +1,11 @@
 import type { Locale } from '@/core'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the export plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/export
  */
-/* eslint-enable tsdoc/syntax */
 
 /**
  * German locales for export plugin.

--- a/src/plugins/export/store.ts
+++ b/src/plugins/export/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/export/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Interaction } from 'ol/interaction'
 import type { ExportFormat } from './types'
@@ -19,13 +17,12 @@ import { convertToPdf } from './utils/convertToPdf'
 import { CrossOriginMonkey } from './utils/CrossOriginMonkey'
 import { downloadAsImage } from './utils/downloadAsImage'
 import { getCanvasFromMap } from './utils/getCanvasFromMap'
-/* eslint-disable tsdoc/syntax */
+
 /**
  * @function
  *
  * Plugin store for export functionality.
  */
-/* eslint-enable tsdoc/syntax */
 export const useExportStore = defineStore('plugins/export', () => {
 	const coreStore = useCoreStore()
 	const exportedMap = ref('')

--- a/src/plugins/filter/index.ts
+++ b/src/plugins/filter/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/filter
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { FilterPluginOptions } from './types'
@@ -15,7 +13,7 @@ import { PluginId } from './types'
 /**
  * Creates a plugin which allows to filter arbitrary configurable vector layers by their properties.
  *
- * @returns Plugin for use with {@link addPlugin}
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginFilter(
 	options: FilterPluginOptions

--- a/src/plugins/filter/locales.ts
+++ b/src/plugins/filter/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the filter plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/filter
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/filter/store.ts
+++ b/src/plugins/filter/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/filter/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import { acceptHMRUpdate, defineStore, storeToRefs } from 'pinia'
 import { watch } from 'vue'
@@ -14,13 +12,11 @@ import { useFilterMainStore } from './stores/main'
 import { useFilterTimeStore } from './stores/time'
 import { updateFeatureVisibility } from './utils/updateFeatureVisibility'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for filtering features.
  */
-/* eslint-enable tsdoc/syntax */
 export const useFilterStore = defineStore('plugins/filter', () => {
 	const filterMainStore = useFilterMainStore()
 	const filterMainStoreRefs = storeToRefs(filterMainStore)

--- a/src/plugins/filter/types.ts
+++ b/src/plugins/filter/types.ts
@@ -31,7 +31,7 @@ export interface CategoryValue {
 	/**
 	 * An icon that is assigned to the value for filtering.
 	 *
-	 * Only usable if {@link MapConfiguration.layout | layout} is set to `'standard'`.
+	 * Only usable if {@link @polar/polar!MapConfiguration.layout | layout} is set to `'standard'`.
 	 */
 	icon?: Icon
 }

--- a/src/plugins/footer/index.ts
+++ b/src/plugins/footer/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/footer
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { FooterPluginOptions } from './types'
@@ -18,7 +16,7 @@ import { PluginId } from './types'
  *
  * Note that a link to the POLAR repository will always be displayed.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginFooter(
 	options: FooterPluginOptions

--- a/src/plugins/footer/locales.ts
+++ b/src/plugins/footer/locales.ts
@@ -1,13 +1,11 @@
 import type { Locale } from '@/core'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the footer plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/footer
  */
-/* eslint-enable tsdoc/syntax */
 
 /**
  * German locales for footer plugin.

--- a/src/plugins/footer/store.ts
+++ b/src/plugins/footer/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/footer/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Component } from 'vue'
 import type { PluginContainer } from '@/core'
@@ -13,13 +11,11 @@ import { markRaw, ref } from 'vue'
 
 import { useCoreStore } from '@/core/stores'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for the footer.
  */
-/* eslint-enable tsdoc/syntax */
 export const useFooterStore = defineStore('plugins/footer', () => {
 	const coreStore = useCoreStore()
 

--- a/src/plugins/fullscreen/index.ts
+++ b/src/plugins/fullscreen/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/fullscreen
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { FullscreenPluginOptions } from './types'
@@ -15,7 +13,7 @@ import { PluginId } from './types'
 /**
  * Creates a plugin which provides a fullscreen mode with a fullscreen toggle button.
  *
- * @returns Plugin for use with {@link addPlugin}
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginFullscreen(
 	options: FullscreenPluginOptions = {}

--- a/src/plugins/fullscreen/locales.ts
+++ b/src/plugins/fullscreen/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the fullscreen plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/fullscreen
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/fullscreen/store.ts
+++ b/src/plugins/fullscreen/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/fullscreen/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Reactive } from 'vue'
 import type { FullscreenPluginOptions } from './types'
@@ -14,13 +12,11 @@ import { useCoreStore } from '@/core/stores'
 
 import { PluginId } from './types'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for fullscreen mode detection and enablement.
  */
-/* eslint-enable tsdoc/syntax */
 export const useFullscreenStore = defineStore('plugins/fullscreen', () => {
 	const coreStore = useCoreStore()
 

--- a/src/plugins/geoLocation/index.ts
+++ b/src/plugins/geoLocation/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/geoLocation
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { GeoLocationPluginOptions } from './types'
@@ -20,7 +18,7 @@ import { PluginId } from './types'
  * If a users denies the location tracking, the button for this plugin gets
  * disabled and indicates the user's decision.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginGeoLocation(
 	options: GeoLocationPluginOptions

--- a/src/plugins/geoLocation/locales.ts
+++ b/src/plugins/geoLocation/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the geoLocation plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/geoLocation
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/geoLocation/store.ts
+++ b/src/plugins/geoLocation/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/geoLocation/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Coordinate } from 'ol/coordinate'
 import type { ObjectEvent } from 'ol/Object'
@@ -32,13 +30,11 @@ import { detectDeniedGeolocationEarly } from './utils/detectDeniedGeolocationEar
 import { getGeoLocationStyle } from './utils/olStyle'
 import { positionChanged } from './utils/positionChanged'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for geoLocation.
  */
-/* eslint-enable tsdoc/syntax */
 export const useGeoLocationStore = defineStore('plugins/geoLocation', () => {
 	const coreStore = useCoreStore()
 

--- a/src/plugins/iconMenu/index.ts
+++ b/src/plugins/iconMenu/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/iconMenu
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { IconMenuPluginOptions } from './types'
@@ -20,7 +18,7 @@ import { PluginId } from './types'
  * Please use carefully – users may have issues finding process-relevant
  * buttons or interactions if you hide them here.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginIconMenu(
 	options: IconMenuPluginOptions

--- a/src/plugins/iconMenu/locales.ts
+++ b/src/plugins/iconMenu/locales.ts
@@ -1,13 +1,11 @@
 import type { Locale } from '@/core'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the iconMenu plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/iconMenu
  */
-/* eslint-enable tsdoc/syntax */
 
 /**
  * German locales for iconMenu plugin.

--- a/src/plugins/iconMenu/store.ts
+++ b/src/plugins/iconMenu/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/iconMenu/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Component } from 'vue'
 import type { Icon } from '@/core'
@@ -17,13 +15,11 @@ import { useCoreStore } from '@/core/stores'
 
 import { PluginId } from './types'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for the icon menu.
  */
-/* eslint-enable tsdoc/syntax */
 export const useIconMenuStore = defineStore('plugins/iconMenu', () => {
 	const coreStore = useCoreStore()
 

--- a/src/plugins/iconMenu/types.ts
+++ b/src/plugins/iconMenu/types.ts
@@ -15,7 +15,7 @@ export interface Menu {
 	 * configured plugin. If not given, render the plugin content as is inside the IconMenu.
 	 *
 	 * Current examples for the usage without icon include Zoom and Fullscreen if
-	 * {@link MapConfiguration.layout | `layout`} is set to `'nineRegions'`
+	 * {@link @polar/polar!MapConfiguration.layout | `layout`} is set to `'nineRegions'`
 	 */
 	icon?: string
 }
@@ -26,9 +26,9 @@ export interface Menu {
 export interface IconMenuPluginOptions extends PluginOptions {
 	/**
 	 * Defines which plugins should be rendered as part of the icon menu.
-	 * If {@link MapConfiguration.layout | `layout`} is set to `'standard'`, multiple groups can be
+	 * If {@link @polar/polar!MapConfiguration.layout | `layout`} is set to `'standard'`, multiple groups can be
 	 * added through different arrays to differentiate plugins visually. Using multiple groups (arrays) doesn't yield any
-	 * change if {@link MapConfiguration.layout | `layout`} is set to `'nineRegions'`.
+	 * change if {@link @polar/polar!MapConfiguration.layout | `layout`} is set to `'nineRegions'`.
 	 *
 	 * @example
 	 * ```
@@ -56,7 +56,7 @@ export interface IconMenuPluginOptions extends PluginOptions {
 	menus: Array<Menu[]>
 
 	/**
-	 * If {@link MapConfiguration.layout | `layout`} is set to `'nineRegions'`, then this parameter
+	 * If {@link @polar/polar!MapConfiguration.layout | `layout`} is set to `'nineRegions'`, then this parameter
 	 * allows overriding the `IconMenuButton.vue` component for custom design and functionality. Coding knowledge is required
 	 * to use this feature, as any implementation will have to rely upon the Pinia store model and has to implement the
 	 * same props as the default `IconMenuButton.vue`. Please refer to the implementation.
@@ -72,7 +72,7 @@ export interface IconMenuPluginOptions extends PluginOptions {
 	focusInitiallyOpen?: string
 
 	/**
-	 * If {@link MapConfiguration.layout | `layout`} is set to `'standard'`, a second menu that includes
+	 * If {@link @polar/polar!MapConfiguration.layout | `layout`} is set to `'standard'`, a second menu that includes
 	 * the hints as labels of the buttons is being displayed at the bottom of the map.
 	 *
 	 * Content is shown in the top left corner.
@@ -91,7 +91,7 @@ export interface IconMenuPluginOptions extends PluginOptions {
 	initiallyOpen?: string
 
 	/**
-	 * If {@link MapConfiguration.layout | `mapConfiguration.layers`} is set to `'nineRegions'`, then this parameter
+	 * If {@link @polar/polar!MapConfiguration.layout | `mapConfiguration.layers`} is set to `'nineRegions'`, then this parameter
 	 * declares the positioning of the IconMenu. However, if {@link buttonComponent} is not set, then only `"TOP_RIGHT"`
 	 * is allowed as value.
 	 */

--- a/src/plugins/layerChooser/index.ts
+++ b/src/plugins/layerChooser/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/layerChooser
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PluginOptions, PolarPluginStore } from '@/core'
 
@@ -19,10 +17,10 @@ import { PluginId } from './types'
  * Order of layers within a layer is always as initially configured.
  *
  * The tool does not require any configuration for itself but is based on the
- * {@link MapConfiguration.layers | `mapConfiguration.layers`}.
+ * {@link @polar/polar!MapConfiguration.layers | `mapConfiguration.layers`}.
  * It will infer `id` and `name` from that configuration.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginLayerChooser(
 	options: PluginOptions

--- a/src/plugins/layerChooser/locales.ts
+++ b/src/plugins/layerChooser/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the layerChooser plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/layerChooser
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/layerChooser/store.ts
+++ b/src/plugins/layerChooser/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/layerChooser/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type Layer from 'ol/layer/Layer'
 import type { ImageWMS, TileWMS } from 'ol/source'
@@ -23,13 +21,11 @@ import {
 import { getBackgroundsAndMasks } from './utils/getBackgroundsAndMasks'
 import { prepareLegends } from './utils/prepareLegends'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for the layer chooser.
  */
-/* eslint-enable tsdoc/syntax */
 export const useLayerChooserStore = defineStore('plugins/layerChooser', () => {
 	const coreStore = useCoreStore()
 

--- a/src/plugins/loadingIndicator/index.ts
+++ b/src/plugins/loadingIndicator/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/loadingIndicator
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { LoadingIndicatorOptions } from './types'
@@ -15,7 +13,7 @@ import { PluginId } from './types'
  * Creates a plugin that offers a generic loading indicator that may be used by
  * any plugin or outside procedure to indicate loading.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginLoadingIndicator(
 	options: LoadingIndicatorOptions

--- a/src/plugins/loadingIndicator/store.ts
+++ b/src/plugins/loadingIndicator/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/loadingIndicator/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
@@ -20,13 +18,11 @@ const styles = [
 
 export type LoaderStyles = (typeof styles)[number]
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for the loading indicator.
  */
-/* eslint-enable tsdoc/syntax */
 export const useLoadingIndicatorStore = defineStore(
 	'plugins/loadingIndicator',
 	() => {

--- a/src/plugins/pins/index.ts
+++ b/src/plugins/pins/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/pins
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { PinsPluginOptions } from './types'
@@ -19,7 +17,7 @@ import { PluginId } from './types'
  * coordinate for further steps. The plugin may react to other plugins,
  * especially address searches.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginPins(
 	options: PinsPluginOptions

--- a/src/plugins/pins/locales.ts
+++ b/src/plugins/pins/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the pins plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/pins
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/pins/store.ts
+++ b/src/plugins/pins/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/pins/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { GeoJsonGeometryTypes, Point as GeoJsonPoint } from 'geojson'
 import type { MapBrowserEvent } from 'ol'
@@ -28,14 +26,12 @@ import { getPinStyle } from './utils/getPinStyle'
 import { getPointCoordinate } from './utils/getPointCoordinate'
 import { isCoordinateInBoundaryLayer } from './utils/isCoordinateInBoundaryLayer'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for adding a pin to the map for e.g. coordinate retrieval or
  * marking the location of a found address.
  */
-/* eslint-enable tsdoc/syntax */
 export const usePinsStore = defineStore('plugins/pins', () => {
 	const coreStore = useCoreStore()
 

--- a/src/plugins/pins/types.ts
+++ b/src/plugins/pins/types.ts
@@ -102,7 +102,7 @@ interface InitialPin {
 	/**
 	 * Coordinate reference system in which the given coordinates are encoded.
 	 *
-	 * Defaults to {@link MapConfiguration.epsg | `mapConfiguration.epsg`}.
+	 * Defaults to {@link @polar/polar!MapConfiguration.epsg | `mapConfiguration.epsg`}.
 	 */
 	epsg?: string
 }

--- a/src/plugins/pointerPosition/index.ts
+++ b/src/plugins/pointerPosition/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/pointerPosition
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { PointerPositionPluginOptions } from './types'
@@ -17,7 +15,7 @@ import { PluginId } from './types'
  * as coordinates. An optional select menu is configurable to allow users to
  * switch to their preferred coordinate reference system.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginPointerPosition(
 	options: PointerPositionPluginOptions

--- a/src/plugins/pointerPosition/locales.ts
+++ b/src/plugins/pointerPosition/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the pointerPosition plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/pointerPosition
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/pointerPosition/store.ts
+++ b/src/plugins/pointerPosition/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/pointerPosition/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Coordinate } from 'ol/coordinate'
 
@@ -13,13 +11,11 @@ import { computed, ref } from 'vue'
 
 import { useCoreStore } from '@/core/stores'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for the pointerPosition.
  */
-/* eslint-enable tsdoc/syntax */
 export const usePointerPositionStore = defineStore(
 	'plugins/pointerPosition',
 	() => {
@@ -102,7 +98,7 @@ export const usePointerPositionStore = defineStore(
 
 			/**
 			 * Array of available projections; either configured set or
-			 * {@link MasterportalApiConfiguration.namedProjections | `mapConfiguration.namedProjections`}.
+			 * {@link @polar/polar!MasterportalApiConfiguration.namedProjections | `mapConfiguration.namedProjections`}.
 			 * @alpha
 			 */
 			availableProjections,

--- a/src/plugins/pointerPosition/types.ts
+++ b/src/plugins/pointerPosition/types.ts
@@ -5,7 +5,7 @@ export const PluginId = 'pointerPosition'
 export interface PointerPositionProjection {
 	/**
 	 * Configured codes must be defined via the core's configuration field
-	 * {@link MasterportalApiConfiguration.namedProjections | `mapConfiguration.namedProjections`} or its default value.
+	 * {@link @polar/polar!MasterportalApiConfiguration.namedProjections | `mapConfiguration.namedProjections`} or its default value.
 	 */
 	code: `EPSG:${string}`
 
@@ -19,9 +19,9 @@ export interface PointerPositionProjection {
 
 export interface PointerPositionPluginOptions extends PluginOptions {
 	/**
-	 * List of which projections from the {@link MasterportalApiConfiguration.namedProjections | `mapConfiguration.namedProjections`} to
+	 * List of which projections from the {@link @polar/polar!MasterportalApiConfiguration.namedProjections | `mapConfiguration.namedProjections`} to
 	 * use, i.e., only a subset can be chosen here. If not given, all EPSG
-	 * systems configured in {@link MasterportalApiConfiguration.namedProjections | `mapConfiguration.namedProjections`} will be chosen.
+	 * systems configured in {@link @polar/polar!MasterportalApiConfiguration.namedProjections | `mapConfiguration.namedProjections`} will be chosen.
 	 * In both cases, the coordinate reference system that is first in the
 	 * list will be used as initial selection. If only one system is
 	 * available, the selection element will be omitted.

--- a/src/plugins/reverseGeocoder/index.ts
+++ b/src/plugins/reverseGeocoder/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/reverseGeocoder
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { ReverseGeocoderPluginOptions } from './types'
@@ -13,7 +11,7 @@ import { PluginId } from './types'
 /**
  * Creates a plugin which converts coordinates into addresses.
  *
- * @returns Plugin for use with {@link addPlugin}
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginReverseGeocoder(
 	options: ReverseGeocoderPluginOptions

--- a/src/plugins/reverseGeocoder/store.ts
+++ b/src/plugins/reverseGeocoder/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/reverseGeocoder/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Mock } from 'vitest'
 import type { Reactive } from 'vue'
@@ -23,13 +21,11 @@ import { indicateLoading } from '@/lib/indicateLoading'
 import { PluginId } from './types'
 import { reverseGeocode as reverseGeocodeUtil } from './utils/reverseGeocode'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for reverse geocoder that converts coordinates into addresses.
  */
-/* eslint-enable tsdoc/syntax */
 export const useReverseGeocoderStore = defineStore(
 	'plugins/reverseGeocoder',
 	() => {

--- a/src/plugins/scale/index.ts
+++ b/src/plugins/scale/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/scale
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { ScalePluginOptions } from './types'
@@ -17,9 +15,9 @@ export { calculateScaleFromResolution } from './utils/calculateScaleFromResoluti
 
 /**
  * Creates a plugin that shows the scale as "1 : x", relative to a line, and/or as a scale selection element.
- * Its options are defined by the zoom options defined by configuration of the {@link MasterportalApiConfiguration.options | `mapConfiguration.options`}.
+ * Its options are defined by the zoom options defined by configuration of the {@link @polar/polar!MasterportalApiConfiguration.options | `mapConfiguration.options`}.
  *
- * @returns Plugin for use with {@link addPlugin}.
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}.
  */
 export default function pluginScale(
 	options: ScalePluginOptions

--- a/src/plugins/scale/locales.ts
+++ b/src/plugins/scale/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the scale plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/scale
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/scale/store.ts
+++ b/src/plugins/scale/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/scale/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import { t } from 'i18next'
 import { acceptHMRUpdate, defineStore } from 'pinia'
@@ -16,13 +14,11 @@ import { PluginId } from './types'
 import { beautifyScale } from './utils/beautifyScale'
 import { calculateScaleFromResolution } from './utils/calculateScaleFromResolution'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for the scale.
  */
-/* eslint-enable tsdoc/syntax */
 export const useScaleStore = defineStore('plugins/scale', () => {
 	const coreStore = useCoreStore()
 	const { dpi } = useDpi()
@@ -94,7 +90,7 @@ export const useScaleStore = defineStore('plugins/scale', () => {
 
 	return {
 		/**
-		 * If {@link MapConfiguration.layout | `mapConfiguration.layout`} is set to `'nineRegions'`,
+		 * If {@link @polar/polar!MapConfiguration.layout | `mapConfiguration.layout`} is set to `'nineRegions'`,
 		 * then this parameter declares the positioning of the ScaleWidget.
 		 * @alpha
 		 */

--- a/src/plugins/scale/types.ts
+++ b/src/plugins/scale/types.ts
@@ -6,7 +6,7 @@ export interface ScalePluginOptions extends PluginOptions {
 	/**
 	 * If set to `true`, the `1 : x` text will be replaced with a select element
 	 * that allows switching between scale values. Requires the configuration
-	 * parameter {@link MapConfiguration.options} to be set.
+	 * parameter {@link @polar/polar!MapConfiguration.options} to be set.
 	 * @defaultValue false
 	 */
 	showScaleSwitcher?: boolean

--- a/src/plugins/toast/index.ts
+++ b/src/plugins/toast/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/toast
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { ToastPluginOptions } from './types'
@@ -19,7 +17,7 @@ import { PluginId } from './types'
  * These are the classic success, warning, info, and error messages,
  * helping to understand what's going on or why something happened.
  *
- * @returns Plugin for use with {@link addPlugin}
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginToast(
 	options: ToastPluginOptions

--- a/src/plugins/toast/locales.ts
+++ b/src/plugins/toast/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the toast plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/toast
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/toast/store.ts
+++ b/src/plugins/toast/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/toast/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Reactive } from 'vue'
 import type {
@@ -26,13 +24,11 @@ interface ToastItem {
 	timeout?: ReturnType<typeof setTimeout>
 }
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for showing messages to the user.
  */
-/* eslint-enable tsdoc/syntax */
 export const useToastStore = defineStore('plugins/toast', () => {
 	const coreStore = useCoreStore()
 

--- a/src/plugins/zoom/index.ts
+++ b/src/plugins/zoom/index.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/zoom
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { PluginContainer, PolarPluginStore } from '@/core'
 import type { ZoomPluginOptions } from './types'
@@ -15,7 +13,7 @@ import { PluginId } from './types'
 /**
  * Creates a plugin which provides UI and functionality regarding zooming.
  *
- * @returns Plugin for use with {@link addPlugin}
+ * @returns Plugin for use with {@link @polar/polar!addPlugin | addPlugin}
  */
 export default function pluginZoom(
 	options: ZoomPluginOptions = {}

--- a/src/plugins/zoom/locales.ts
+++ b/src/plugins/zoom/locales.ts
@@ -1,11 +1,9 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * This is the documentation for the locales keys in the zoom plugin.
  * These locales are *NOT* exported, but documented only.
  *
  * @module locales/plugins/zoom
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { Locale } from '@/core'
 

--- a/src/plugins/zoom/store.ts
+++ b/src/plugins/zoom/store.ts
@@ -1,8 +1,6 @@
-/* eslint-disable tsdoc/syntax */
 /**
  * @module \@polar/polar/plugins/zoom/store
  */
-/* eslint-enable tsdoc/syntax */
 
 import type { ComputedRef } from 'vue'
 import type { ZoomPluginOptions } from './types'
@@ -14,13 +12,11 @@ import { useCoreStore } from '@/core/stores'
 
 import { PluginId } from './types'
 
-/* eslint-disable tsdoc/syntax */
 /**
  * @function
  *
  * Plugin store for zoom buttons and zoom slider.
  */
-/* eslint-enable tsdoc/syntax */
 export const useZoomStore = defineStore('plugins/zoom', () => {
 	const coreStore = useCoreStore()
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -10,6 +10,15 @@
 	],
 	"out": "docs-html/reference",
 	"skipErrorChecking": true,
+	"validation": {
+		"notExported": false,
+		"invalidLink": true,
+		"rewrittenLink": true,
+		"notDocumented": false,
+		"unusedMergeModuleWith": true
+	},
+	"treatWarningsAsErrors": false,
+	"treatValidationWarningsAsErrors": true,
 	"projectDocuments": [],
 	"name": "POLAR reference",
 	"sort": [


### PR DESCRIPTION
## Summary

- All `@link` references are fixed.
- Typedoc-conformity is now validated via CI.
- The ESLint rule `tsdoc/syntax` is disabled (replaced by typedoc-validation).

## Instructions for local reproduction and review

- Pipeline succeeds.
- View the documentation.

## Relevant tickets, issues, et cetera

Fixes #671 