### PR TITLE
docs: remove theme font via google

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,9 @@ site_name: POLAR
 site_url: https://dataport.github.io/polar/docs/
 site_dir: docs-html/docs
 
-theme: material
+theme:
+  name: material
+  font: false
 
 exclude_docs: |
   /assets/**/*.md


### PR DESCRIPTION
## Summary

Remove references to `fonts.googleapis.com` from the generated markdown docs.

## Additional hints

Cherry-picked from live branch and working there.