### PR TITLE
feat: disallow blank issues and enable security advisories

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions & Discussions
+    url: https://github.com/Dataport/polar/discussions
+    about: Use GitHub discussions for message-board style questions and discussions.
+  - name: Report a security vulnerability
+    url: https://github.com/Dataport/polar/security/advisories/new
+    about: Please report security issues privately here instead of opening a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,10 @@ Before proceeding, please mind our [code of conduct](https://github.com/Dataport
 ## Reporting Issues
 
 Should you find bugs, feel free to add them as [issues](https://github.com/Dataport/polar/issues). A bug template is provided.
-You may also contact us via polar@dataport.de.
+You may also contact us via [polar@dataport.de](mailto:polar@dataport.de).
+
+For security vulnerabilities, please do not open a public issue.
+Report them privately as described in our [security policy](https://github.com/Dataport/polar/blob/main/security.md).
 
 ## Contributing Code
 

--- a/security.md
+++ b/security.md
@@ -2,7 +2,13 @@
 
 ## Reporting a vulnerability
 
-If you discover a security vulnerability within this project, please send an e-mail to polar@dataport.de.
+Please report security vulnerabilities privately so they can be fixed before becoming public.
+Do not open a regular public issue for security concerns.
+
+You have two ways to report a vulnerability:
+
+1. **Preferred:** Use GitHub's [private vulnerability reporting](https://github.com/Dataport/polar/security/advisories/new). This opens a confidential advisory thread with the maintainers directly on GitHub.
+2. **Alternatively:** Send an e-mail to [polar@dataport.de](mailto:polar@dataport.de?subject=Security%20vulnerability%20report).
 
 Please include, if available, the following information in your report:
 


### PR DESCRIPTION
## Summary

Disallowed blank issues and links to security advisories for vulnerabilities

## Instructions for local reproduction and review

Read and approve.

## Relevant tickets, issues, et cetera

Private vulnerability reporting under Security and quality has to be enabled together with this PR.
