### PR TITLE
docs(arch): add architectural decisions from backlog

### DIFF
--- a/docs/architecture/decisions/ADR-0005.md
+++ b/docs/architecture/decisions/ADR-0005.md
@@ -1,4 +1,4 @@
-# Difference between actions, utils and lib-packages
+# Difference between actions, utils and lib-functions
 
 ## Status
 
@@ -6,7 +6,7 @@ Accepted.
 
 ## Context
 
-`actions`, `utils` and `lib`-packages can often consist of very similar code. It was not always clear enough where to place certain functionality, which was ultimately up to each developers own preference.
+`actions`, `utils` and [`lib`](../../../src/lib)-functions can often consist of very similar code. It was not always clear enough where to place certain functionality, which was ultimately up to each developers own preference.
 
 ## Decision
 
@@ -16,7 +16,7 @@ When deciding on where to place code (when writing or refactoring), the followin
 * Should the functionality be usable outside of an integrated client? `action`
 * Does the functionality **not** have state changes, but belongs to a certain `action`? Either locally in the same file as the `action` or in a folder named after the `action` in the path `store/ACTIONNAME`
 * Does the functionality **not** have state changes, but be reusable in the plugin / core? `utils`
-* Should the functionality be reusable for multiple plugins / the core? `lib`-package 
+* Should the functionality be reusable for multiple plugins / the core? [`lib`](../../../src/lib)-function
 
 ## Consequences
 

--- a/docs/architecture/decisions/ADR-0012.md
+++ b/docs/architecture/decisions/ADR-0012.md
@@ -15,7 +15,7 @@ The convention is enforced by commitlint in a commit-msg git hook.
 
 ## Consequences
 
-- (+) Changelogs can be generated from the commit history.
+- (+) Changelogs may be generated from the commit history.
 - (+) Breaking changes are documented clearly.
 - (+) Bugfixes and features are clearly separated.
 - (-) Multiple merge requests may be necessary to avoid mixing a bugfix and a feature if we would squash merge.

--- a/docs/architecture/decisions/ADR-0012.md
+++ b/docs/architecture/decisions/ADR-0012.md
@@ -11,7 +11,7 @@ Commit messages in POLAR do not follow a common convention. This makes it hard t
 ## Decision
 
 We use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
-The convention is enforced by commitlint in a commit-msg git hook.
+The convention is enforced by `commitlint` in a commit-msg git hook.
 
 ## Consequences
 

--- a/docs/architecture/decisions/ADR-0012.md
+++ b/docs/architecture/decisions/ADR-0012.md
@@ -1,0 +1,21 @@
+# Use Conventional Commits
+
+## Status
+
+Accepted.
+
+## Context
+
+Commit messages in POLAR do not follow a common convention. This makes it hard to tell bugfixes and features apart, to recognize breaking changes, and to derive release notes from the repository history.
+
+## Decision
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) for commit messages.
+The convention is enforced by commitlint in a commit-msg git hook.
+
+## Consequences
+
+- (+) Changelogs can be generated from the commit history.
+- (+) Breaking changes are documented clearly.
+- (+) Bugfixes and features are clearly separated.
+- (-) Multiple merge requests may be necessary to avoid mixing a bugfix and a feature if we would squash merge.

--- a/docs/architecture/decisions/ADR-0013.md
+++ b/docs/architecture/decisions/ADR-0013.md
@@ -21,4 +21,4 @@ We use the Composition API, both in components and in stores.
 - (+) Logic can be extracted into composables and reused across components and plugins.
 - (+) Type inference works without additional tooling or helper types.
 - (+) It is the style the Vue ecosystem, including Pinia, is built around.
-- (-) Contributors familiar with the Options API of the Vue 2 codebase have to learn the Composition API.
+- (-) Contributors familiar with the Options API of the `vue@2` codebase have to learn the Composition API.

--- a/docs/architecture/decisions/ADR-0013.md
+++ b/docs/architecture/decisions/ADR-0013.md
@@ -7,7 +7,7 @@ Accepted.
 ## Context
 
 The rewrite introduced by ADR 0009 is based on `vue@3`, which [offers two ways](https://vuejs.org/guide/introduction.html#api-styles) of authoring components: the Options API and the Composition API.
-The previous Vue 2 codebase used the Options API together with Vuex.
+The previous `vue@2` codebase used the Options API together with Vuex.
 
 Since a rewrite is happening anyway, it has to be decided which of the two is used.
 

--- a/docs/architecture/decisions/ADR-0013.md
+++ b/docs/architecture/decisions/ADR-0013.md
@@ -6,7 +6,7 @@ Accepted.
 
 ## Context
 
-The rewrite introduced by ADR 0009 is based on Vue 3, which offers two ways of authoring components: the Options API and the Composition API.
+The rewrite introduced by ADR 0009 is based on `vue@3`, which [offers two ways](https://vuejs.org/guide/introduction.html#api-styles) of authoring components: the Options API and the Composition API.
 The previous Vue 2 codebase used the Options API together with Vuex.
 
 Since a rewrite is happening anyway, it has to be decided which of the two is used.

--- a/docs/architecture/decisions/ADR-0013.md
+++ b/docs/architecture/decisions/ADR-0013.md
@@ -1,0 +1,24 @@
+# Usage of Composition API
+
+## Status
+
+Accepted.
+
+## Context
+
+The rewrite introduced by ADR 0009 is based on Vue 3, which offers two ways of authoring components: the Options API and the Composition API.
+The previous Vue 2 codebase used the Options API together with Vuex.
+
+Since a rewrite is happening anyway, it has to be decided which of the two is used.
+
+## Decision
+
+We use the Composition API, both in components and in stores.
+
+## Consequences
+
+- (+) Related logic is grouped by concern instead of being spread over lifecycle hooks and options.
+- (+) Logic can be extracted into composables and reused across components and plugins.
+- (+) Type inference works without additional tooling or helper types.
+- (+) It is the style the Vue ecosystem, including Pinia, is built around.
+- (-) Contributors familiar with the Options API of the Vue 2 codebase have to learn the Composition API.

--- a/docs/architecture/decisions/ADR-0014.md
+++ b/docs/architecture/decisions/ADR-0014.md
@@ -6,7 +6,7 @@ Accepted.
 
 ## Context
 
-The previous Vue 2 codebase used jest for unit and component tests, which required additional transformers and configuration to work with TypeScript and single-file components.
+The previous `vue@2` codebase used `jest` for unit and component tests, which required additional transformers and configuration to work with TypeScript and single-file components.
 
 The rewrite introduced by ADR 0009 is built with vite, so the test runner should fit that toolchain.
 

--- a/docs/architecture/decisions/ADR-0014.md
+++ b/docs/architecture/decisions/ADR-0014.md
@@ -16,7 +16,7 @@ We use `vitest` as test runner.
 
 ## Consequences
 
-- (+) The vite configuration, including aliases and plugins, is reused for tests, so there is no second build setup to maintain.
+- (+) The `vite` configuration, including aliases and plugins, is reused for tests, so there is no second build setup to maintain.
 - (+) No additional transformers are needed for TypeScript and single-file components.
 - (+) Features such as in-source testing become available.
 - (o) Tests written for jest have to be migrated, although the API is largely compatible.

--- a/docs/architecture/decisions/ADR-0014.md
+++ b/docs/architecture/decisions/ADR-0014.md
@@ -12,7 +12,7 @@ The rewrite introduced by ADR 0009 is built with `vite`, so the test runner shou
 
 ## Decision
 
-We use vitest as test runner.
+We use `vitest` as test runner.
 
 ## Consequences
 

--- a/docs/architecture/decisions/ADR-0014.md
+++ b/docs/architecture/decisions/ADR-0014.md
@@ -19,4 +19,4 @@ We use `vitest` as test runner.
 - (+) The `vite` configuration, including aliases and plugins, is reused for tests, so there is no second build setup to maintain.
 - (+) No additional transformers are needed for TypeScript and single-file components.
 - (+) Features such as in-source testing become available.
-- (o) Tests written for jest have to be migrated, although the API is largely compatible.
+- (o) Tests written for `jest` have to be migrated, although the API is largely compatible.

--- a/docs/architecture/decisions/ADR-0014.md
+++ b/docs/architecture/decisions/ADR-0014.md
@@ -8,7 +8,7 @@ Accepted.
 
 The previous `vue@2` codebase used `jest` for unit and component tests, which required additional transformers and configuration to work with TypeScript and single-file components.
 
-The rewrite introduced by ADR 0009 is built with vite, so the test runner should fit that toolchain.
+The rewrite introduced by ADR 0009 is built with `vite`, so the test runner should fit that toolchain.
 
 ## Decision
 

--- a/docs/architecture/decisions/ADR-0014.md
+++ b/docs/architecture/decisions/ADR-0014.md
@@ -1,0 +1,22 @@
+# Usage of vitest
+
+## Status
+
+Accepted.
+
+## Context
+
+The previous Vue 2 codebase used jest for unit and component tests, which required additional transformers and configuration to work with TypeScript and single-file components.
+
+The rewrite introduced by ADR 0009 is built with vite, so the test runner should fit that toolchain.
+
+## Decision
+
+We use vitest as test runner.
+
+## Consequences
+
+- (+) The vite configuration, including aliases and plugins, is reused for tests, so there is no second build setup to maintain.
+- (+) No additional transformers are needed for TypeScript and single-file components.
+- (+) Features such as in-source testing become available.
+- (o) Tests written for jest have to be migrated, although the API is largely compatible.

--- a/docs/architecture/decisions/ADR-0015.md
+++ b/docs/architecture/decisions/ADR-0015.md
@@ -1,0 +1,25 @@
+# Exported files
+
+## Status
+
+Accepted.
+
+## Context
+
+POLAR is consumed as a library.
+It has to be decided which parts of the core and of the plugins are part of the public API, since everything that is exported has to be maintained and is subject to SemVer.
+
+Consumers need to read and change state at runtime (e.g. to react to a selected feature or to open a plugin's UI programmatically).
+At the same time, plugins are not only state, but also UI, locales and options that need to be usable as a whole.
+However, we want to allow users to use the state with a custom UI.
+
+## Decision
+
+- We export a public-facing store for the core and for each plugin.
+  The store exports everything that is used by the UI.
+- We export the whole plugin, i.e. its UI components, locales, options and store, as a single unit.
+
+## Consequences
+
+- (+) The public API is explicit and can be documented and typed.
+- (+) Consumers can use a plugin as a whole without having to assemble UI, locales and store themselves.

--- a/docs/architecture/decisions/ADR-0016.md
+++ b/docs/architecture/decisions/ADR-0016.md
@@ -23,7 +23,7 @@ KERN offers multiple ways of consuming it:
 ## Decision
 
 We use `@kern-ux/native`.
-Larger wrapping components are maintained in `src/components/kern` to avoid repeating the HTML boilerplate.
+Components reused across the project are maintained in `src/components` to avoid repeating the HTML boilerplate.
 
 ## Consequences
 

--- a/docs/architecture/decisions/ADR-0016.md
+++ b/docs/architecture/decisions/ADR-0016.md
@@ -29,4 +29,4 @@ Components reused across the project are maintained in `src/components` to avoid
 
 - (+) The rendered markup is fully under our control and can be adjusted where POLAR requires it.
 - (+) No nesting of web components within web components is necessary.
-- (-) The wrapping components in `src/components/kern` have to be maintained by us and kept in sync with KERN updates.
+- (-) The wrapping components in `src/components` have to be maintained by us and kept in sync with KERN updates.

--- a/docs/architecture/decisions/ADR-0016.md
+++ b/docs/architecture/decisions/ADR-0016.md
@@ -1,0 +1,32 @@
+# Usage of KERN
+
+## Status
+
+Accepted.
+
+## Context
+
+POLAR has to comply with the KERN UX design system.
+KERN offers multiple ways of consuming it:
+
+- `@kern-ux/native`: plain CSS and HTML
+  - (+) Flexible, since we write the HTML elements ourselves.
+  - (+) Only official (not only community-based) KERN package
+  - (-) We either have to maintain our own components or write the rather long HTML again and again.
+- The WebC Light Kit, i.e. KERN as web components
+  - (-) Web components within web components, as POLAR itself is a web component.
+  - (-) Some components do not work well within web components.
+  - (-) Adjustments to the components are barely possible.
+- The Vue Kit, i.e. KERN as Vue components
+  - (-) Adjustments to the components are barely possible.
+
+## Decision
+
+We use `@kern-ux/native`.
+Larger wrapping components are maintained in `src/components/kern` to avoid repeating the HTML boilerplate.
+
+## Consequences
+
+- (+) The rendered markup is fully under our control and can be adjusted where POLAR requires it.
+- (+) No nesting of web components within web components is necessary.
+- (-) The wrapping components in `src/components/kern` have to be maintained by us and kept in sync with KERN updates.

--- a/docs/architecture/decisions/ADR-0017.md
+++ b/docs/architecture/decisions/ADR-0017.md
@@ -1,0 +1,32 @@
+# Usage of SFC CSS Modules and removal of SCSS/Sass
+
+## Status
+
+Accepted.
+
+## Context
+
+Styles in POLAR are currently written as scoped styles in single-file components, partly using SCSS/Sass.
+
+Two questions were raised:
+
+- Should [SFC CSS Modules](https://vuejs.org/api/sfc-css-features.html#css-modules) be used to scope styles?
+  It has to be clarified whether they work with custom elements.
+- Is SCSS/Sass still required?
+  The features we use it for - nested styles, colour functions and variables - are available as native CSS by now.
+  Nesting and `oklch` are baseline, and SCSS variables can be replaced by CSS variables.
+
+## Decision
+
+- We do not use SFC CSS Modules.
+  They are not supported with Vue custom elements, which POLAR is built from.
+- We use SFC CSS Modules in the iceberg test client.
+- We remove SCSS/Sass and write plain CSS instead, using native nesting, `oklch` and CSS variables.
+
+## Consequences
+
+- (+) One build step and one dependency less.
+- (+) Styles are written in standard CSS, which lowers the entry barrier for contributors.
+- (+) CSS variables can be changed at runtime and by consumers, which SCSS variables cannot.
+- (o) Existing SCSS styles have to be migrated to plain CSS.
+- (-) Style scoping keeps relying on Vue's `scoped` attribute instead of CSS Modules.

--- a/docs/architecture/decisions/ADR-0018.md
+++ b/docs/architecture/decisions/ADR-0018.md
@@ -1,0 +1,27 @@
+# Test file placement
+
+## Status
+
+Accepted.
+
+## Context
+
+ADR 0014 decided that vitest is used for testing.
+It still has to be decided where tests are placed.
+
+Vitest supports [in-source testing](https://vitest.dev/guide/in-source.html), i.e. tests that live inside the module they test, next to the implementation.
+This is not possible for component tests or end-to-end tests.
+
+## Decision
+
+- Unit tests are written as in-source tests within the module they test.
+- Component tests are written in a separate file next to the component, i.e., in the same folder, e.g. `Fullscreen.spec.ts` next to `Fullscreen.ce.vue`.
+- End-to-end tests are placed in a dedicated `e2e` folder.
+
+## Consequences
+
+- (+) Unit tests are close to the implementation, which makes them easier to find and keep up to date.
+- (+) Private functions can be tested without exporting them only for testing purposes.
+- (+) The kind of a test can be derived from its location.
+- (o) In-source tests have to be stripped from the production build.
+- (-) Implementation files become longer.

--- a/docs/architecture/decisions/ADR-0019.md
+++ b/docs/architecture/decisions/ADR-0019.md
@@ -1,0 +1,31 @@
+# Maturity of documented API members
+
+## Status
+
+Accepted.
+
+## Context
+
+ADR 0015 decided that plugins only use the public-facing store of the core.
+As a consequence, getters and actions that were previously considered core-internal and therefore undocumented now have to be part of the exported store, since plugins rely on them.
+
+Documenting them without further qualification would imply that they are stable and part of the public API of POLAR, which they are not.
+
+## Decision
+
+Everything that is used across module boundaries is part of the exported store and is documented, but annotated with a maturity tag stating the intended audience:
+
+- `@internal`: The member is only used within the core. It is not shown to plugin or client developers.
+- `@alpha`: The member is used by the core and its plugins, but is not part of the public API. It may change within a major version and is not shown to client developers.
+- `@beta`: The member is not yet part of the public API, but will probably become part of the public API in a later version.
+- No tag: The member is part of the public API and is subject to SemVer.
+
+The reference documentation is generated for different target audiences (core, plugin and client developers).
+
+## Consequences
+
+- (+) All members used across module boundaries are documented, no matter their maturity.
+- (+) The stability guarantees of a member are explicit and machine-readable.
+- (+) The generated reference can be filtered per target audience.
+- (o) The maturity of a member has to be re-evaluated whenever its usage changes.
+- (-) Members marked `@alpha` may break for plugin developers within a major version.

--- a/docs/architecture/decisions/ADR-0020.md
+++ b/docs/architecture/decisions/ADR-0020.md
@@ -21,7 +21,7 @@ Additionally, it has to be decided which units are used for sizes and spacings.
 
 - `Fira Sans` is included by default, but can be switched off, e.g. to use the font of the surrounding environment or to avoid loading a font that is already present.
 - Sizes and spacings are expressed using the [KERN variables for sizes and spacings](https://www.kern-ux.de/design-system/foundations/groesse-und-abstaende) and the [KERN typography scale](https://www.kern-ux.de/design-system/foundations/typografie#typografieskala).
-- Where there is a reason not to use the KERN variables, relative units are used, that is `rem` instead of `px`, and `%`, `em` and similar where appropriate.
+- Where there is a reason not to use the KERN variables, relative units are used: `rem` instead of `px`, and `%`, `em` and similar where appropriate.
 
 ## Consequences
 

--- a/docs/architecture/decisions/ADR-0020.md
+++ b/docs/architecture/decisions/ADR-0020.md
@@ -1,0 +1,32 @@
+# Handling of fonts and sizes
+
+## Status
+
+Accepted.
+
+## Context
+
+ADR 0016 decided that POLAR uses KERN.
+KERN specifies `Fira Sans` as its font, which raises multiple questions.
+
+Should `Fira Sans` always be included, or only on demand?
+
+- (+) We want to comply with KERN.
+- (-) Users may want to deviate from it.
+- (-) If the surrounding environment already provides `Fira Sans`, it is loaded twice.
+
+Additionally, it has to be decided which units are used for sizes and spacings.
+
+## Decision
+
+- `Fira Sans` is included by default, but can be switched off, e.g. to use the font of the surrounding environment or to avoid loading a font that is already present.
+- Sizes and spacings are expressed using the [KERN variables for sizes and spacings](https://www.kern-ux.de/design-system/foundations/groesse-und-abstaende) and the [KERN typography scale](https://www.kern-ux.de/design-system/foundations/typografie#typografieskala).
+- Where there is a reason not to use the KERN variables, relative units are used, that is `rem` instead of `px`, and `%`, `em` and similar where appropriate.
+
+## Consequences
+
+- (+) POLAR complies with KERN out of the box, without further configuration.
+- (+) Clients can adapt POLAR to the typography of the surrounding environment.
+- (+) Duplicate loading of the font can be avoided.
+- (+) Using relative units respects the font size configured by the user, which benefits accessibility.
+- (o) The opt-out has to be documented for client developers.

--- a/docs/architecture/decisions/ADR-0021.md
+++ b/docs/architecture/decisions/ADR-0021.md
@@ -1,0 +1,37 @@
+# Structure of stores regarding state and actions
+
+## Status
+
+Accepted.
+
+## Context
+
+It has to be decided how (plugin) stores are structured regarding the separation of state and actions.
+Several styles were considered.
+
+- A: State is only changed through actions, every state value is readonly from the outside.
+  - (+) All effects of a change are collected in the action.
+  - (-) Additional actions are required every time, which causes unnecessary complexity.
+  - (-) `readonly` has to be implemented every time, both technically and in the documentation.
+  - (-) Changing state through an action is less intuitive.
+- B: The above only applies if changing the state has an effect that is encoded within the store. Otherwise the state value is mutable.
+  - (-) The mutability of a value has to be changed whenever new side effects arise.
+- C: State is mutable in principle, as far as changing it is meaningful at all. Derived values are preferably determined via `computed`, alternatively via `watch`.
+  - (+) State is always mutable and therefore the easiest to use.
+  - (+) Watchers are already used for inter-plugin communication anyway.
+  - (-) Effects are harder to grasp, as they are not collected centrally in an action.
+- D: We do not make any rules; everyone writes according to personal preference.
+  - (+) Personal freedom is preserved.
+  - (-) The design of the plugins becomes rather inconsistent.
+
+## Decision
+
+State is mutable, derived values are expressed as `computed`.
+We try to avoid `watch`ers if possible.
+
+## Consequences
+
+- (+) Stores are consistent across plugins.
+- (+) Side effects are collected in an action instead of being spread over the store.
+- (-) Watchers, which are harder to follow than actions, remain necessary for rare cases.
+- (-) Consumers need to look up a matching action to change state.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,17 @@ nav:
       - architecture/decisions/ADR-0008.md
       - architecture/decisions/ADR-0009.md
       - architecture/decisions/ADR-0010.md
+      - architecture/decisions/ADR-0011.md
+      - architecture/decisions/ADR-0012.md
+      - architecture/decisions/ADR-0013.md
+      - architecture/decisions/ADR-0014.md
+      - architecture/decisions/ADR-0015.md
+      - architecture/decisions/ADR-0016.md
+      - architecture/decisions/ADR-0017.md
+      - architecture/decisions/ADR-0018.md
+      - architecture/decisions/ADR-0019.md
+      - architecture/decisions/ADR-0020.md
+      - architecture/decisions/ADR-0021.md
   - development.md
   - contact.md
   - legal-notice.md


### PR DESCRIPTION
Within our internal weekly, we had a growing backlog of not-yet-published architectural decisions. These are now introduced to the repository.