### PR TITLE
chore: allow lib imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
 		"./plugins/*/store": {
 			"types": "./dist/plugin-*-store.d.ts",
 			"default": "./dist/plugin-*-store.js"
+		},
+		"./lib/*": {
+			"types": "./dist/lib/*.d.ts",
+			"default": "./dist/lib/*.js"
 		}
 	},
 	"repository": {

--- a/src/lib/getCluster.ts
+++ b/src/lib/getCluster.ts
@@ -8,7 +8,11 @@ import VectorLayer from 'ol/layer/Vector'
  * Helper function to retrieve the related cluster of a feature.
  * Returns the feature if it's a cluster feature, or the cluster the feature is in.
  */
-export default function (map: Map, feature: Feature, layerId: string): Feature {
+export default function getCluster(
+	map: Map,
+	feature: Feature,
+	layerId: string
+): Feature {
 	if (feature.get('features')) {
 		return feature
 	}

--- a/src/lib/getFeatures/bkg.ts
+++ b/src/lib/getFeatures/bkg.ts
@@ -34,7 +34,7 @@ function getRequestUrlQuery(
 	return query
 }
 
-export default async function (
+export default async function bkg(
 	signal: AbortSignal,
 	url: string,
 	inputValue: string,

--- a/src/lib/getFeatures/mpapi.ts
+++ b/src/lib/getFeatures/mpapi.ts
@@ -7,7 +7,7 @@ import { transform } from 'ol/proj'
 
 // AbortSignal is not used as the AbortController is implemented by @masterportal/masterportalapi
 
-export default async function (
+export default async function mpapi(
 	_: AbortSignal,
 	url: string,
 	input: string,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import vue from '@vitejs/plugin-vue'
-import { globSync } from 'node:fs'
-import { basename, resolve, sep } from 'node:path'
+import { globSync, readdirSync } from 'node:fs'
+import { basename, join, relative, resolve, sep } from 'node:path'
 import dts from 'unplugin-dts/vite'
 import { defineConfig } from 'vite'
 import checker from 'vite-plugin-checker'
@@ -9,6 +9,49 @@ import kernExtraIcons from 'vite-plugin-kern-extra-icons'
 import vueDevTools from 'vite-plugin-vue-devtools'
 
 import enrichedConsole from './vitePlugins/enrichedConsole.js'
+
+/**
+ * Collects public `lib` entries for subpath exports (e.g.`@polar/polar/lib/invisibleStyle`).
+ * A directory with an `index.ts` is exposed only via its folder path;
+ * otherwise each `.ts` file is exposed and subdirectories are traversed.
+ */
+function collectLibEntries() {
+	const baseDir = resolve(__dirname, 'src')
+	const entries: Record<string, string> = {}
+
+	const toKey = (absPath: string) =>
+		relative(baseDir, absPath).split(sep).join('/')
+	const addEntry = (key: string, file: string) => {
+		if (entries[key]) {
+			console.warn(
+				`[vite.config] Duplicate lib entry key "${key}"; ignoring "${file}".`
+			)
+			return
+		}
+		entries[key] = file
+	}
+	const walk = (currentDir: string) => {
+		const items = readdirSync(currentDir, { withFileTypes: true })
+		if (items.some((item) => item.isFile() && item.name === 'index.ts')) {
+			addEntry(toKey(currentDir), join(currentDir, 'index.ts'))
+			return
+		}
+		for (const item of items) {
+			const full = join(currentDir, item.name)
+			if (item.isDirectory()) {
+				walk(full)
+			} else if (item.isFile() && item.name.endsWith('.ts')) {
+				addEntry(toKey(full).replace(/\.ts$/, ''), full)
+			}
+		}
+	}
+
+	walk(join(baseDir, 'lib'))
+
+	return entries
+}
+
+const libEntries = collectLibEntries()
 
 export default defineConfig(({ mode }) => ({
 	plugins: [
@@ -63,6 +106,7 @@ export default defineConfig(({ mode }) => ({
 						[`plugin-${basename(path)}-store`, [path, 'store.ts'].join(sep)],
 					])
 				),
+				...libEntries,
 			},
 		},
 		sourcemap: true,
@@ -91,6 +135,13 @@ export default defineConfig(({ mode }) => ({
 									`@polar/polar/plugins/${basename(path)}`,
 									resolve(path, 'index.ts'),
 								],
+							])
+						),
+						// lib keys are never a prefix of one another, so their order is irrelevant.
+						...Object.fromEntries(
+							Object.entries(libEntries).map(([key, file]) => [
+								`@polar/polar/${key}`,
+								file,
 							])
 						),
 						'@polar/polar/client': resolve(__dirname, 'src', 'client.ts'),


### PR DESCRIPTION
## Summary

Expose lib-functions so they can be imported by clients.

## Instructions for local reproduction and review

- `npm run snowbox` should run without any problems.
- Importing e.g. `isVisible` from `@polar/polar/lib/invisibleStyle` should work now without any problems

## Relevant tickets, issues, et cetera

Closes #918
Relevant for #447
