### PR TITLE
Feat/routing marker drag

### DIFF
--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -45,13 +45,16 @@ export function useMarkerLayer(
 	})
 
 	const modify = new Modify({ source: markerSource })
-	modify.on('modifyend', () => {
-		route.value = markerSource.getFeatures().map((feature) => {
+	modify.on('modifyend', (evt) => {
+		const allFeatures = markerSource.getFeatures()
+		evt.features.forEach((feature) => {
 			const geometry = feature.getGeometry()
 			if (geometry instanceof Point) {
-				return geometry.getCoordinates()
+				const index = allFeatures.indexOf(feature)
+				if (index !== -1 && index < route.value.length) {
+					route.value[index] = geometry.getCoordinates()
+				}
 			}
-			return []
 		})
 	})
 

--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -55,4 +55,10 @@ export function useMarkerLayer(
 		})
 	})
 	map.addInteraction(modify)
+
+	map.on('pointermove', function (evt) {
+		const pixel = map.getEventPixel(evt.originalEvent)
+		const hit = map.hasFeatureAtPixel(pixel)
+		map.getTargetElement().style.cursor = hit ? 'pointer' : ''
+	})
 }

--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -55,7 +55,7 @@ export function useMarkerLayer(
 		})
 	})
 
-	map.on('pointermove', function (evt) {
+	map.on('pointermove', (evt) => {
 		const pixel = map.getEventPixel(evt.originalEvent)
 		const hit = map.hasFeatureAtPixel(pixel)
 		if (

--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -5,6 +5,7 @@ import type { Ref } from 'vue'
 
 import { Feature } from 'ol'
 import { Point } from 'ol/geom'
+import Modify from 'ol/interaction/Modify'
 import VectorLayer from 'ol/layer/Vector'
 import { Circle, Fill, Stroke, Style } from 'ol/style'
 import { onScopeDispose, watch } from 'vue'
@@ -42,4 +43,16 @@ export function useMarkerLayer(
 			}
 		})
 	})
+
+	const modify = new Modify({ source: markerSource })
+	modify.on('modifyend', () => {
+		route.value = markerSource.getFeatures().map((feature) => {
+			const geometry = feature.getGeometry()
+			if (geometry instanceof Point) {
+				return geometry.getCoordinates()
+			}
+			return []
+		})
+	})
+	map.addInteraction(modify)
 }

--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -74,3 +74,150 @@ export function useMarkerLayer(
 
 	map.addInteraction(modify)
 }
+
+if (import.meta.vitest) {
+	const { describe, it, beforeEach, afterEach, vi, expect } = import.meta.vitest
+	const { effectScope, ref, nextTick } = await import('vue')
+
+	vi.mock('ol/interaction/Modify', () => ({
+		default: vi.fn().mockImplementation(function (this: {
+			on: ReturnType<typeof vi.fn>
+		}) {
+			this.on = vi.fn()
+		}),
+	}))
+
+	vi.mock('ol/layer/Vector', () => ({
+		default: vi.fn().mockImplementation(function () {}),
+	}))
+
+	describe('useMarkerLayer', () => {
+		let route: Ref<Coordinate[]>
+		let markerSource: {
+			addFeature: ReturnType<typeof vi.fn>
+			clear: ReturnType<typeof vi.fn>
+			getFeature: ReturnType<typeof vi.fn>
+			getFeatures: ReturnType<typeof vi.fn>
+		}
+		let map: {
+			addLayer: ReturnType<typeof vi.fn>
+			removeLayer: ReturnType<typeof vi.fn>
+			addInteraction: ReturnType<typeof vi.fn>
+			on: ReturnType<typeof vi.fn>
+			hasFeatureAtPixel: ReturnType<typeof vi.fn>
+			getEventPixel: ReturnType<typeof vi.fn>
+			getTargetElement: ReturnType<typeof vi.fn>
+		}
+		let mapElement: { style: { cursor: string } }
+
+		beforeEach(() => {
+			route = ref<Coordinate[]>([])
+			mapElement = { style: { cursor: '' } }
+			markerSource = {
+				addFeature: vi.fn(),
+				clear: vi.fn(),
+				getFeature: vi.fn(),
+				getFeatures: vi.fn().mockReturnValue([{ id: 1 }]),
+			}
+			map = {
+				addLayer: vi.fn(),
+				removeLayer: vi.fn(),
+				addInteraction: vi.fn(),
+				on: vi.fn(),
+				hasFeatureAtPixel: vi.fn().mockReturnValue(false),
+				getEventPixel: vi.fn().mockReturnValue([0, 0]),
+				getTargetElement: vi.fn().mockReturnValue(mapElement),
+			}
+		})
+
+		afterEach(() => {
+			vi.clearAllMocks()
+		})
+
+		it('should check if the layer has been added to the map', () => {
+			const scope = effectScope()
+			scope.run(() => {
+				useMarkerLayer(
+					map as unknown as Map,
+					markerSource as unknown as VectorSource,
+					route
+				)
+			})
+
+			expect(map.addLayer).toHaveBeenCalledOnce()
+
+			scope.stop()
+		})
+
+		it('should check whether modify interaction has been added to the map', () => {
+			const scope = effectScope()
+			scope.run(() => {
+				useMarkerLayer(
+					map as unknown as Map,
+					markerSource as unknown as VectorSource,
+					route
+				)
+			})
+
+			expect(map.addInteraction).toHaveBeenCalledOnce()
+
+			scope.stop()
+		})
+
+		it('should check if the layer has been removed from the map on scope disposal', () => {
+			const scope = effectScope()
+			scope.run(() => {
+				useMarkerLayer(
+					map as unknown as Map,
+					markerSource as unknown as VectorSource,
+					route
+				)
+			})
+
+			expect(map.removeLayer).not.toHaveBeenCalled()
+			scope.stop()
+			expect(map.removeLayer).toHaveBeenCalledOnce()
+		})
+
+		it('clears and fills markerSource when route changes', async () => {
+			const scope = effectScope()
+			scope.run(() => {
+				useMarkerLayer(
+					map as unknown as Map,
+					markerSource as unknown as VectorSource,
+					route
+				)
+			})
+			route.value = [
+				[1, 2],
+				[3, 4],
+			]
+			await nextTick()
+			expect(markerSource.addFeature).toHaveBeenCalledTimes(2)
+			route.value[0] = [2, 5]
+			await nextTick()
+			expect(markerSource.clear).toHaveBeenCalledOnce()
+			scope.stop()
+		})
+
+		it('skips empty coordinates when route changes', async () => {
+			const scope = effectScope()
+			scope.run(() => {
+				useMarkerLayer(
+					map as unknown as Map,
+					markerSource as unknown as VectorSource,
+					route
+				)
+			})
+
+			route.value = [[1, 2], []]
+			await nextTick()
+			expect(markerSource.addFeature).toHaveBeenCalledOnce()
+			route.value[2] = [4, 7]
+			route.value[0] = [2, 5]
+			await nextTick()
+			expect(markerSource.addFeature).toHaveBeenCalledOnce()
+			scope.stop()
+		})
+	})
+}

--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -5,6 +5,7 @@ import type { Ref } from 'vue'
 
 import { Feature } from 'ol'
 import { Point } from 'ol/geom'
+import Modify from 'ol/interaction/Modify'
 import VectorLayer from 'ol/layer/Vector'
 import { Circle, Fill, Stroke, Style } from 'ol/style'
 import { onScopeDispose, watch } from 'vue'
@@ -41,5 +42,31 @@ export function useMarkerLayer(
 				)
 			}
 		})
+	})
+
+	const modify = new Modify({ source: markerSource })
+	modify.on('modifyend', () => {
+		route.value = markerSource.getFeatures().map((feature) => {
+			const geometry = feature.getGeometry()
+			if (geometry instanceof Point) {
+				return geometry.getCoordinates()
+			}
+			return []
+		})
+	})
+	map.addInteraction(modify)
+
+	map.on('pointermove', function (evt) {
+		const pixel = map.getEventPixel(evt.originalEvent)
+		const hit = map.hasFeatureAtPixel(pixel)
+		if (
+			'buttons' in evt.originalEvent &&
+			(evt.originalEvent as PointerEvent).buttons === 1 &&
+			hit
+		) {
+			map.getTargetElement().style.cursor = 'grabbing'
+		} else {
+			map.getTargetElement().style.cursor = hit ? 'grab' : ''
+		}
 	})
 }

--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -76,6 +76,7 @@ export function useMarkerLayer(
 }
 
 if (import.meta.vitest) {
+	const { default: VectorSource } = await import('ol/source/Vector')
 	const { describe, it, beforeEach, afterEach, vi, expect } = import.meta.vitest
 	const { effectScope, ref, nextTick } = await import('vue')
 
@@ -93,40 +94,22 @@ if (import.meta.vitest) {
 
 	describe('useMarkerLayer', () => {
 		let route: Ref<Coordinate[]>
-		let markerSource: {
-			addFeature: ReturnType<typeof vi.fn>
-			clear: ReturnType<typeof vi.fn>
-			getFeature: ReturnType<typeof vi.fn>
-			getFeatures: ReturnType<typeof vi.fn>
-		}
 		let map: {
 			addLayer: ReturnType<typeof vi.fn>
 			removeLayer: ReturnType<typeof vi.fn>
 			addInteraction: ReturnType<typeof vi.fn>
 			on: ReturnType<typeof vi.fn>
-			hasFeatureAtPixel: ReturnType<typeof vi.fn>
-			getEventPixel: ReturnType<typeof vi.fn>
-			getTargetElement: ReturnType<typeof vi.fn>
 		}
-		let mapElement: { style: { cursor: string } }
+		let markerSource: VectorSource
 
 		beforeEach(() => {
 			route = ref<Coordinate[]>([])
-			mapElement = { style: { cursor: '' } }
-			markerSource = {
-				addFeature: vi.fn(),
-				clear: vi.fn(),
-				getFeature: vi.fn(),
-				getFeatures: vi.fn().mockReturnValue([{ id: 1 }]),
-			}
+			markerSource = new VectorSource()
 			map = {
 				addLayer: vi.fn(),
 				removeLayer: vi.fn(),
 				addInteraction: vi.fn(),
 				on: vi.fn(),
-				hasFeatureAtPixel: vi.fn().mockReturnValue(false),
-				getEventPixel: vi.fn().mockReturnValue([0, 0]),
-				getTargetElement: vi.fn().mockReturnValue(mapElement),
 			}
 		})
 
@@ -180,6 +163,8 @@ if (import.meta.vitest) {
 		})
 
 		it('clears and fills markerSource when route changes', async () => {
+			const addFeatureSpy = vi.spyOn(markerSource, 'addFeature')
+			const clearSpy = vi.spyOn(markerSource, 'clear')
 			const scope = effectScope()
 			scope.run(() => {
 				useMarkerLayer(
@@ -193,14 +178,19 @@ if (import.meta.vitest) {
 				[3, 4],
 			]
 			await nextTick()
-			expect(markerSource.addFeature).toHaveBeenCalledTimes(2)
-			route.value[0] = [2, 5]
+			expect(addFeatureSpy).toHaveBeenCalledTimes(2)
+			route.value = [
+				[2, 5],
+				[3, 4],
+			]
 			await nextTick()
-			expect(markerSource.clear).toHaveBeenCalledOnce()
+			expect(clearSpy).toHaveBeenCalledTimes(2)
+			expect(addFeatureSpy).toHaveBeenCalledTimes(4)
 			scope.stop()
 		})
 
 		it('skips empty coordinates when route changes', async () => {
+			const addFeatureSpy = vi.spyOn(markerSource, 'addFeature')
 			const scope = effectScope()
 			scope.run(() => {
 				useMarkerLayer(
@@ -212,11 +202,10 @@ if (import.meta.vitest) {
 
 			route.value = [[1, 2], []]
 			await nextTick()
-			expect(markerSource.addFeature).toHaveBeenCalledOnce()
-			route.value[2] = [4, 7]
-			route.value[0] = [2, 5]
+			expect(addFeatureSpy).toHaveBeenCalledOnce()
+			route.value = [[2, 5], [], [4, 7]]
 			await nextTick()
-			expect(markerSource.addFeature).toHaveBeenCalledOnce()
+			expect(addFeatureSpy).toHaveBeenCalledTimes(3)
 			scope.stop()
 		})
 	})

--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -54,7 +54,6 @@ export function useMarkerLayer(
 			return []
 		})
 	})
-	map.addInteraction(modify)
 
 	map.on('pointermove', function (evt) {
 		const pixel = map.getEventPixel(evt.originalEvent)
@@ -69,4 +68,6 @@ export function useMarkerLayer(
 			map.getTargetElement().style.cursor = hit ? 'grab' : ''
 		}
 	})
+
+	map.addInteraction(modify)
 }

--- a/src/plugins/routing/composables/useMarkerLayer.ts
+++ b/src/plugins/routing/composables/useMarkerLayer.ts
@@ -33,11 +33,12 @@ export function useMarkerLayer(
 
 	watch(route, () => {
 		markerSource.clear()
-		route.value.forEach((coordinate) => {
+		route.value.forEach((coordinate, index) => {
 			if (coordinate.length) {
 				markerSource.addFeature(
 					new Feature({
 						geometry: new Point(coordinate),
+						routeIndex: index,
 					})
 				)
 			}
@@ -46,12 +47,11 @@ export function useMarkerLayer(
 
 	const modify = new Modify({ source: markerSource })
 	modify.on('modifyend', (evt) => {
-		const allFeatures = markerSource.getFeatures()
 		evt.features.forEach((feature) => {
 			const geometry = feature.getGeometry()
 			if (geometry instanceof Point) {
-				const index = allFeatures.indexOf(feature)
-				if (index !== -1 && index < route.value.length) {
+				const index = feature.get('routeIndex')
+				if (index < route.value.length && typeof index === 'number') {
 					route.value[index] = geometry.getCoordinates()
 				}
 			}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -115,6 +115,7 @@ export default defineConfig(({ mode }) => ({
 		},
 	},
 	test: {
+		globals: true,
 		environment: 'jsdom',
 		include: ['src/**/*.spec.ts'],
 		includeSource: ['src/**/*.ts'],


### PR DESCRIPTION
## Summary

Add a dragging-feature to the markers of an existing route.

## Instructions for local reproduction and review

- add apiKey from HeiGit to PluginRouting in example/snowbox/index.js
- select start and destination in the route plugin
- select one of the markers and drag them to a new location on the map
