### PR TITLE
Fix/wobbliness on shift zoom

### DIFF
--- a/src/core/utils/interactions.ts
+++ b/src/core/utils/interactions.ts
@@ -1,6 +1,10 @@
 import type { MapBrowserEvent } from 'ol'
 
-import { platformModifierKeyOnly } from 'ol/events/condition'
+import {
+	noModifierKeys,
+	platformModifierKeyOnly,
+	primaryAction,
+} from 'ol/events/condition'
 import {
 	DragPan,
 	KeyboardPan,
@@ -30,9 +34,11 @@ export function createPanAndZoomInteractions(
 	}
 	return [
 		new DragPan({
-			condition: function () {
-				// @ts-expect-error | As the DragPan is added to the interactions of the map, the 'this' context of the condition function should always be defined.
-				return hasSmallScreen ? this.getPointerCount() > 1 : true
+			condition: function (e) {
+				return hasSmallScreen
+					? // @ts-expect-error | As the DragPan is added to the interactions of the map, the 'this' context of the condition function should always be defined.
+						this.getPointerCount() > 1
+					: noModifierKeys(e) && primaryAction(e)
 			},
 		}),
 		new MouseWheelZoom({


### PR DESCRIPTION
## Summary

`DragPan` would also fire during `DragBox` interactions due to missing checks. `DragPan#options.condition` default value according to [docs](https://openlayers.org/en/latest/apidoc/module-ol_interaction_DragPan-DragPan.html) has been set as `condition` for non-small-screen devices.

## Instructions for local reproduction and review

Run snowbox and Shift(hold)+Drag on via mouse. Check on mobile if panning still works.

## Pull Request Checklist (for Assignee)

- [x] Functionality has been tested in Firefox, Chrome, ~~Safari~~
- [x] Functionality has been tested on a smartphone

## Relevant tickets, issues, et cetera

Resolves https://github.com/Dataport/polar/issues/965