### PR TITLE
Fix masterportalapi defaults

### DIFF
--- a/src/core/utils/map/olDefaultStyle.ts
+++ b/src/core/utils/map/olDefaultStyle.ts
@@ -1,0 +1,25 @@
+import { Circle, Fill, Stroke, Style } from 'ol/style.js'
+
+const fill = new Fill({
+	color: 'rgba(255,255,255,0.4)',
+})
+const stroke = new Stroke({
+	color: '#3399CC',
+	width: 1.25,
+})
+
+/**
+ * OL default style according to their style documentation:
+ * https://openlayers.org/en/latest/apidoc/module-ol_style_Style-Style.html
+ */
+export const styles = [
+	new Style({
+		image: new Circle({
+			fill,
+			stroke,
+			radius: 5,
+		}),
+		fill,
+		stroke,
+	}),
+]

--- a/src/core/utils/map/setupStyling.ts
+++ b/src/core/utils/map/setupStyling.ts
@@ -6,15 +6,35 @@ import type {
 	MasterportalApiServiceRegister,
 } from '../../types'
 
+import { setCustomStyles } from '@masterportal/masterportalapi/src/layer/geojson'
 import createStyle from '@masterportal/masterportalapi/src/vectorStyle/createStyle'
 import styleList from '@masterportal/masterportalapi/src/vectorStyle/styleList'
 import noop from '@repositoryname/noop'
+
+import { styles } from './olDefaultStyle'
+
+const changeMasterportalApiDefaults = () => {
+	setCustomStyles({
+		// required by masterportalAPI
+		/* eslint-disable @typescript-eslint/naming-convention */
+		Point: styles,
+		LineString: styles,
+		MultiLineString: styles,
+		MultiPoint: styles,
+		MultiPolygon: styles,
+		Polygon: styles,
+		GeometryCollection: styles,
+		Circle: styles,
+		/* eslint-enable @typescript-eslint/naming-convention */
+	})
+}
 
 export async function setupStyling(
 	map: Map,
 	configuration: MapConfiguration,
 	register: MasterportalApiServiceRegister
 ) {
+	changeMasterportalApiDefaults()
 	if (configuration.featureStyles && Array.isArray(register)) {
 		await styleList.initializeStyleList(
 			// Masterportal specific field not required by POLAR


### PR DESCRIPTION
## Summary

Somehow the default marker design from the masterportalAPI doesn't work at the moment. However, our docs say that we use the OL default anyway:

https://github.com/Dataport/polar/blob/22fd5540ffac9cf25b4a4506e6f8b47ab8641071/src/core/types/layer.ts#L121-L127

Hence, the OL default is now used, and markers will only appear if we configure them to.

## Instructions for local reproduction and review

Remove `markers` entry in snowbox. Patch is in issue if you prefer that route. Run snowbox, receive styles.

## Pull Request Checklist (for Assignee)

- [x] Functionality has been tested in Chrome

## Relevant tickets, issues, et cetera

Resolves https://github.com/Dataport/polar/issues/959