### PR TITLE
Fix confusing reverseGeocode error

### DIFF
--- a/src/plugins/reverseGeocoder/store.ts
+++ b/src/plugins/reverseGeocoder/store.ts
@@ -23,7 +23,10 @@ import { indicateLoading } from '@/lib/indicateLoading'
 
 import { PluginId } from './types'
 import { reverseGeocodeNominatim } from './utils/reverseGeocodeNominatim'
-import { reverseGeocodeWps } from './utils/reverseGeocodeWps'
+import {
+	addressMissingMessage,
+	reverseGeocodeWps,
+} from './utils/reverseGeocodeWps'
 
 /* eslint-disable tsdoc/syntax */
 /**
@@ -108,7 +111,16 @@ export const useReverseGeocoderStore = defineStore(
 				return feature
 			} catch (error) {
 				if (!signal.aborted) {
-					console.error('Reverse geocoding failed:', error)
+					if (
+						error instanceof Error &&
+						error.message === addressMissingMessage
+					) {
+						console.warn(
+							`Reverse geocoding stopped with message '${addressMissingMessage}'. This indicates the WPS does not support this region.`
+						)
+					} else {
+						console.error('Reverse geocoding failed:', error)
+					}
 				}
 				return null
 			} finally {

--- a/src/plugins/reverseGeocoder/utils/reverseGeocodeWps.ts
+++ b/src/plugins/reverseGeocoder/utils/reverseGeocodeWps.ts
@@ -33,6 +33,9 @@ function getTextContent(parent: Element, localName: string) {
 	return parent.getElementsByTagNameNS('*', localName)[0]?.textContent ?? ''
 }
 
+export const addressMissingMessage =
+	'Response does not contain an "Adresse" element.'
+
 export async function reverseGeocodeWps({
 	url,
 	coordinate,
@@ -61,7 +64,7 @@ export async function reverseGeocodeWps({
 
 	const address = doc.getElementsByTagNameNS('*', 'Adresse')[0]
 	if (!address) {
-		throw new Error('Response does not contain an "Adresse" element.')
+		throw new Error(addressMissingMessage)
 	}
 
 	// NOTE: Property names come from the WPS.


### PR DESCRIPTION
## Summary

The reverseGeocoder error in the console confused me when testfully clicking outside of Hamburg. I've reduced it to a `.warn` and wrote a more verbose message to keep future people unconfused about this.

## Instructions for local reproduction and review

Run snowbox, click outside of Hamburg.

## Pull Request Checklist (for Assignee)

- [x] Functionality has been tested in Chrome

## Relevant tickets, issues, et cetera

Resolves https://github.com/Dataport/polar/issues/958